### PR TITLE
Address header display on narrow phones

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,375 +1,401 @@
 <html lang="en">
 <!-- quite clos but still stress work, tabs TODO -->
+
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta property="og:title" content="SOFA - a simple, organised feed of macOS and iOS update info">
-  <meta property="og:description" content="SOFA supports MacAdmins by efficiently tracking and surfacing information on updates for macOS and iOS.">
-  <link rel="icon" type="image/png" href="images/custom_logo.png">
-  <title>SOFA | A MacAdmin's Simple Organized Feed for Apple Software Updates</title>
-  <link href="./main.css" rel="stylesheet">
-  <style>
-    .text-content {
-      padding-right: 80px;
-      /* Adjust the padding to ensure text does not overlap the image */
-    }
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta property="og:title" content="SOFA - a simple, organised feed of macOS and iOS update info">
+    <meta property="og:description"
+        content="SOFA supports MacAdmins by efficiently tracking and surfacing information on updates for macOS and iOS.">
+    <link rel="icon" type="image/png" href="images/custom_logo.png">
+    <title>SOFA | A MacAdmin's Simple Organized Feed for Apple Software Updates</title>
+    <link href="./main.css" rel="stylesheet">
+    <style>
+        .text-content {
+            padding-right: 80px;
+            /* Adjust the padding to ensure text does not overlap the image */
+        }
 
-    .os-image {
-      position: absolute;
-      top: -30px;
-      /* Adjust the position to let the image float on top */
-      right: 15px;
-      height: 60px;
-      /* Adjust the size of the image as needed */
-      width: auto;
-      border-radius: 50%;
-      /* Circular image */
-    }
+        .os-image {
+            position: absolute;
+            top: -30px;
+            /* Adjust the position to let the image float on top */
+            right: 15px;
+            height: 60px;
+            /* Adjust the size of the image as needed */
+            width: auto;
+            border-radius: 50%;
+            /* Circular image */
+        }
 
-    /* Light mode styles as default */
-    .highlight-cve {
-        background-color: rgb(227, 159, 32); /* Light mode color */
-        box-shadow: 0 0 1px 1px rgb(227, 159, 32);
-    }
+        /* Light mode styles as default */
+        .highlight-cve {
+            background-color: rgb(227, 159, 32);
+            /* Light mode color */
+            box-shadow: 0 0 1px 1px rgb(227, 159, 32);
+        }
 
-    /* Dark mode styles */
-    html.dark .highlight-cve {
-        background-color: rgb(154, 25, 70); /* Dark mode color */
-        box-shadow: 0 0 1px 1px rgb(154, 25, 70);
-    }
-    /* Any additional custom styles */
-  </style>
+        /* Dark mode styles */
+        html.dark .highlight-cve {
+            background-color: rgb(154, 25, 70);
+            /* Dark mode color */
+            box-shadow: 0 0 1px 1px rgb(154, 25, 70);
+        }
+
+        /* Any additional custom styles */
+    </style>
 </head>
 
 
 <body class="bg-gray-50 text-gray-700 dark:bg-gray-900 dark:text-gray-300 font-sans">
     <div class="container mx-auto px-6 py-12">
-      <div class="flex items-center justify-between mb-6">
-        <div class="flex items-center">
-          <img src="images/custom_logo.png" alt="Custom Logo" class="h-20 w-20 mr-4 sm:mr-6">
-          <div class="flex items-center">
-            <h1 class="font-bold text-grey-900 dark:text-grey-100 mr-4">
-              <span class="text-3xl sm:text-4xl">SOFA</span> <!-- Larger on sm screens and up -->
-            </h1>
-            <p class="text-lg sm:text-xl text-grey-900 dark:text-grey-100"> <!-- Smaller on the smallest screens -->
-              Simple Organized Feed for Apple Software Updates
-            </p>
+        <div class="flex items-center justify-between mb-6">
+            <div class="flex items-center">
+                <img src="images/custom_logo.png" alt="Custom Logo" class="h-20 w-20 mr-4 sm:mr-6">
+                <div class="flex items-center">
+                    <h1 class="font-bold text-grey-900 dark:text-grey-100 mr-4">
+                        <span class="text-3xl sm:text-4xl">SOFA</span> <!-- Larger on sm screens and up -->
+                    </h1>
+                    <p class="text-lg sm:text-xl text-grey-900 dark:text-grey-100 hidesmall">
+                        <!-- Hide on the smallest screens -->
+                        Simple Organized Feed for Apple Software Updates
+                    </p>
+                </div>
+            </div>
+            <div class="flex items-center ml-1">
+                <!-- Theme Toggle Button -->
+                <button id="theme-toggle" data-tooltip-target="tooltip-toggle" type="button"
+                    class="inline-flex items-center justify-center hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg w-10 h-10 mr-2">
+                    <svg id="theme-toggle-dark-icon" class="w-4 h-4 hidden" aria-hidden="true"
+                        xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 18 20">
+                        <path
+                            d="M17.8 13.75a1 1 0 0 0-.859-.5A7.488 7.488 0 0 1 10.52 2a1 1 0 0 0 0-.969A1.035 1.035 0 0 0 9.687.5h-.113a9.5 9.5 0 1 0 8.222 14.247 1 1 0 0 0 .004-.997Z">
+                        </path>
+                    </svg>
+                    <svg id="theme-toggle-light-icon" class="w-4 h-4" aria-hidden="true"
+                        xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20">
+                        <path
+                            d="M10 15a5 5 0 1 0 0-10 5 5 0 0 0 0 10Zm0-11a1 1 0 0 0 1-1V1a1 1 0 0 0-2 0v2a1 1 0 0 0 1 1Zm0 12a1 1 0 0 0-1 1v2a1 1 0 1 0 2 0v-2a1 1 0 0 0-1-1ZM4.343 5.757a1 1 0 0 0 1.414-1.414L4.343 2.929a1 1 0 0 0-1.414 1.414l1.414 1.414Zm11.314 8.486a1 1 0 0 0-1.414 1.414l1.414 1.414a1 1 0 0 0 1.414-1.414l-1.414-1.414ZM4 10a1 1 0 0 0-1-1H1a1 1 0 0 0 0 2h2a1 1 0 0 0 1-1Zm15-1h-2a1 1 0 1 0 0 2h2a1 1 0 0 0 0-2ZM4.343 14.243l-1.414 1.414a1 1 0 1 0 1.414 1.414l1.414-1.414a1 1 0 0 0-1.414-1.414ZM14.95 6.05a1 1 0 0 0 .707-.293l1.414-1.414a1 1 0 1 0-1.414-1.414l-1.414 1.414a1 1 0 0 0 .707 1.707Z">
+                        </path>
+                    </svg>
+                </button>
+                <!-- Github Link -->
+                <a href="https://github.com/macadmins/sofa" target="_blank" aria-label="GitHub"
+                    class="inline-flex items-center justify-center hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg w-10 h-10">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 496 512" class="h-5 w-5">
+                        <path
+                            d="M165.9 397.4c0 2-2.3 3.6-5.2 3.6-3.3 .3-5.6-1.3-5.6-3.6 0-2 2.3-3.6 5.2-3.6 3-.3 5.6 1.3 5.6 3.6zm-31.1-4.5c-.7 2 1.3 4.3 4.3 4.9 2.6 1 5.6 0 6.2-2s-1.3-4.3-4.3-5.2c-2.6-.7-5.5 .3-6.2 2.3zm44.2-1.7c-2.9 .7-4.9 2.6-4.6 4.9 .3 2 2.9 3.3 5.9 2.6 2.9-.7 4.9-2.6 4.6-4.6-.3-1.9-3-3.2-5.9-2.9zM244.8 8C106.1 8 0 113.3 0 252c0 110.9 69.8 205.8 169.5 239.2 12.8 2.3 17.3-5.6 17.3-12.1 0-6.2-.3-40.4-.3-61.4 0 0-70 15-84.7-29.8 0 0-11.4-29.1-27.8-36.6 0 0-22.9-15.7 1.6-15.4 0 0 24.9 2 38.6 25.8 21.9 38.6 58.6 27.5 72.9 20.9 2.3-16 8.8-27.1 16-33.7-55.9-6.2-112.3-14.3-112.3-110.5 0-27.5 7.6-41.3 23.6-58.9-2.6-6.5-11.1-33.3 2.6-67.9 20.9-6.5 69 27 69 27 20-5.6 41.5-8.5 62.8-8.5s42.8 2.9 62.8 8.5c0 0 48.1-33.6 69-27 13.7 34.7 5.2 61.4 2.6 67.9 16 17.7 25.8 31.5 25.8 58.9 0 96.5-58.9 104.2-114.8 110.5 9.2 7.9 17 22.9 17 46.4 0 33.7-.3 75.4-.3 83.6 0 6.5 4.6 14.4 17.3 12.1C428.2 457.8 496 362.9 496 252 496 113.3 383.5 8 244.8 8zM97.2 352.9c-1.3 1-1 3.3 .7 5.2 1.6 1.6 3.9 2.3 5.2 1 1.3-1 1-3.3-.7-5.2-1.6-1.6-3.9-2.3-5.2-1zm-10.8-8.1c-.7 1.3 .3 2.9 2.3 3.9 1.6 1 3.6 .7 4.3-.7 .7-1.3-.3-2.9-2.3-3.9-2-.6-3.6-.3-4.3 .7zm32.4 35.6c-1.6 1.3-1 4.3 1.3 6.2 2.3 2.3 5.2 2.6 6.5 1 1.3-1.3 .7-4.3-1.3-6.2-2.2-2.3-5.2-2.6-6.5-1zm-11.4-14.7c-1.6 1-1.6 3.6 0 5.9 1.6 2.3 4.3 3.3 5.6 2.3 1.6-1.3 1.6-3.9 0-6.2-1.4-2.3-4-3.3-5.6-2z" />
+                    </svg>
+                </a>
+            </div>
         </div>
+        <p class="text-lg sm:text-xl text-grey-900 dark:text-grey-100 showsmall">
+            <!-- Show here on the smallest screens -->
+            Simple Organized Feed for Apple Software Updates
+        </p>
+        <div class="flex flex-col sm:flex-row justify-between items-center mb-6">
+            <div id="tabs" class="mb-6 flex"></div>
+            <!-- Adjust search input colors for light mode -->
+            <div class="relative mb-4">
+                <input type="search" id="searchInput" placeholder="Search CVEs..."
+                    class="h-10 bg-gray-100 text-gray-900 placeholder-gray-500 dark:bg-gray-800 dark:text-white dark:placeholder-gray-400 pl-10 pr-4 rounded-lg border-2 border-gray-300 dark:border-gray-700 focus:outline-none focus:border-indigo-500">
+                <div class="absolute top-0 left-0 mt-2 ml-3">
+                    <svg class="text-gray-600 dark:text-gray-400 h-6 w-6" fill="none" stroke-linecap="round"
+                        stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24" stroke="currentColor">
+                        <path d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path>
+                    </svg>
+                </div>
+            </div>
         </div>
-        <div class="flex items-center ml-1">
-          <!-- Theme Toggle Button -->
-          <button id="theme-toggle" data-tooltip-target="tooltip-toggle" type="button" class="inline-flex items-center justify-center hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg w-10 h-10 mr-2">
-            <svg id="theme-toggle-dark-icon" class="w-4 h-4 hidden" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 18 20">
-              <path d="M17.8 13.75a1 1 0 0 0-.859-.5A7.488 7.488 0 0 1 10.52 2a1 1 0 0 0 0-.969A1.035 1.035 0 0 0 9.687.5h-.113a9.5 9.5 0 1 0 8.222 14.247 1 1 0 0 0 .004-.997Z"></path>
-            </svg>
-            <svg id="theme-toggle-light-icon" class="w-4 h-4" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20">
-              <path d="M10 15a5 5 0 1 0 0-10 5 5 0 0 0 0 10Zm0-11a1 1 0 0 0 1-1V1a1 1 0 0 0-2 0v2a1 1 0 0 0 1 1Zm0 12a1 1 0 0 0-1 1v2a1 1 0 1 0 2 0v-2a1 1 0 0 0-1-1ZM4.343 5.757a1 1 0 0 0 1.414-1.414L4.343 2.929a1 1 0 0 0-1.414 1.414l1.414 1.414Zm11.314 8.486a1 1 0 0 0-1.414 1.414l1.414 1.414a1 1 0 0 0 1.414-1.414l-1.414-1.414ZM4 10a1 1 0 0 0-1-1H1a1 1 0 0 0 0 2h2a1 1 0 0 0 1-1Zm15-1h-2a1 1 0 1 0 0 2h2a1 1 0 0 0 0-2ZM4.343 14.243l-1.414 1.414a1 1 0 1 0 1.414 1.414l1.414-1.414a1 1 0 0 0-1.414-1.414ZM14.95 6.05a1 1 0 0 0 .707-.293l1.414-1.414a1 1 0 1 0-1.414-1.414l-1.414 1.414a1 1 0 0 0 .707 1.707Z"></path>
-            </svg>
-          </button>
-          <!-- Github Link -->
-          <a href="https://github.com/macadmins/sofa" target="_blank" aria-label="GitHub" class="inline-flex items-center justify-center hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg w-10 h-10">
-            <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 496 512" class="h-5 w-5">
-              <path d="M165.9 397.4c0 2-2.3 3.6-5.2 3.6-3.3 .3-5.6-1.3-5.6-3.6 0-2 2.3-3.6 5.2-3.6 3-.3 5.6 1.3 5.6 3.6zm-31.1-4.5c-.7 2 1.3 4.3 4.3 4.9 2.6 1 5.6 0 6.2-2s-1.3-4.3-4.3-5.2c-2.6-.7-5.5 .3-6.2 2.3zm44.2-1.7c-2.9 .7-4.9 2.6-4.6 4.9 .3 2 2.9 3.3 5.9 2.6 2.9-.7 4.9-2.6 4.6-4.6-.3-1.9-3-3.2-5.9-2.9zM244.8 8C106.1 8 0 113.3 0 252c0 110.9 69.8 205.8 169.5 239.2 12.8 2.3 17.3-5.6 17.3-12.1 0-6.2-.3-40.4-.3-61.4 0 0-70 15-84.7-29.8 0 0-11.4-29.1-27.8-36.6 0 0-22.9-15.7 1.6-15.4 0 0 24.9 2 38.6 25.8 21.9 38.6 58.6 27.5 72.9 20.9 2.3-16 8.8-27.1 16-33.7-55.9-6.2-112.3-14.3-112.3-110.5 0-27.5 7.6-41.3 23.6-58.9-2.6-6.5-11.1-33.3 2.6-67.9 20.9-6.5 69 27 69 27 20-5.6 41.5-8.5 62.8-8.5s42.8 2.9 62.8 8.5c0 0 48.1-33.6 69-27 13.7 34.7 5.2 61.4 2.6 67.9 16 17.7 25.8 31.5 25.8 58.9 0 96.5-58.9 104.2-114.8 110.5 9.2 7.9 17 22.9 17 46.4 0 33.7-.3 75.4-.3 83.6 0 6.5 4.6 14.4 17.3 12.1C428.2 457.8 496 362.9 496 252 496 113.3 383.5 8 244.8 8zM97.2 352.9c-1.3 1-1 3.3 .7 5.2 1.6 1.6 3.9 2.3 5.2 1 1.3-1 1-3.3-.7-5.2-1.6-1.6-3.9-2.3-5.2-1zm-10.8-8.1c-.7 1.3 .3 2.9 2.3 3.9 1.6 1 3.6 .7 4.3-.7 .7-1.3-.3-2.9-2.3-3.9-2-.6-3.6-.3-4.3 .7zm32.4 35.6c-1.6 1.3-1 4.3 1.3 6.2 2.3 2.3 5.2 2.6 6.5 1 1.3-1.3 .7-4.3-1.3-6.2-2.2-2.3-5.2-2.6-6.5-1zm-11.4-14.7c-1.6 1-1.6 3.6 0 5.9 1.6 2.3 4.3 3.3 5.6 2.3 1.6-1.3 1.6-3.9 0-6.2-1.4-2.3-4-3.3-5.6-2z" />
-          </svg>
-        </a>
-      </div>
+        <!-- Adjust informational text colors for light mode -->
+        <div id="last-checked" class="mb-2 text-indigo-700 dark:text-indigo-400"></div>
+        <div id="machine-readable-feed" class="text-indigo-700 dark:text-indigo-400 mb-6"
+            title="Frequently updated with the latest security patches and updates."></div>
+        <!-- New container for both the version card and XProtect card -->
+
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <!-- Card 1 -->
+            <div id="version-card"
+                class="gradient-border-card relative bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-600 shadow overflow-hidden sm:rounded-lg p-6 flex flex-col">
+                <!-- Dynamic content will be inserted here by JavaScript -->
+
+            </div>
+            <!-- Card 2 -->
+            <div id="xprotect-card"
+                class="gradient-border-card relative bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-600 shadow overflow-hidden sm:rounded-lg p-6 flex flex-col">
+                <!-- Dynamic content will be inserted here by JavaScript -->
+            </div>
+        </div>
+
+        <hr class="border-t-2 border-gray-300 dark:border-gray-700 my-8">
+
+        <div id="security-releases" class="space-y-4">
+            <!-- Adjust headings and link colors for light mode -->
+            <h2 class="text-2xl text-indigo-700 dark:text-indigo-400 font-semibold mb-4">Apple Resources</h2>
+            <a href="https://support.apple.com/en-us/HT201222"
+                class="text-blue-600 hover:text-blue-400 dark:text-yellow-500 dark:hover:text-yellow-300 text-lg">Apple
+                security releases</a>
+        </div>
     </div>
-    <div class="flex flex-col sm:flex-row justify-between items-center mb-6">
-      <div id="tabs" class="mb-6 flex"></div>
-      <!-- Adjust search input colors for light mode -->
-      <div class="relative mb-4">
-        <input type="search" id="searchInput" placeholder="Search CVEs..." class="h-10 bg-gray-100 text-gray-900 placeholder-gray-500 dark:bg-gray-800 dark:text-white dark:placeholder-gray-400 pl-10 pr-4 rounded-lg border-2 border-gray-300 dark:border-gray-700 focus:outline-none focus:border-indigo-500">
-        <div class="absolute top-0 left-0 mt-2 ml-3">
-          <svg class="text-gray-600 dark:text-gray-400 h-6 w-6" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24" stroke="currentColor">
-            <path d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path>
-          </svg>
-        </div>
-      </div>
-    </div>
-    <!-- Adjust informational text colors for light mode -->
-    <div id="last-checked" class="mb-2 text-indigo-700 dark:text-indigo-400"></div>
-    <div id="machine-readable-feed" class="text-indigo-700 dark:text-indigo-400 mb-6" title="Frequently updated with the latest security patches and updates."></div>
-     <!-- New container for both the version card and XProtect card -->
-
-     <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <!-- Card 1 -->
-        <div id="version-card" class="gradient-border-card relative bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-600 shadow overflow-hidden sm:rounded-lg p-6 flex flex-col">
-        <!-- Dynamic content will be inserted here by JavaScript -->
-            
-        </div>
-        <!-- Card 2 -->
-        <div id="xprotect-card" class="gradient-border-card relative bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-600 shadow overflow-hidden sm:rounded-lg p-6 flex flex-col">
-            <!-- Dynamic content will be inserted here by JavaScript -->
-        </div>
-    </div>
-
-    <hr class="border-t-2 border-gray-300 dark:border-gray-700 my-8">
-    
-    <div id="security-releases" class="space-y-4">
-      <!-- Adjust headings and link colors for light mode -->
-      <h2 class="text-2xl text-indigo-700 dark:text-indigo-400 font-semibold mb-4">Apple Resources</h2>
-      <a href="https://support.apple.com/en-us/HT201222" class="text-blue-600 hover:text-blue-400 dark:text-yellow-500 dark:hover:text-yellow-300 text-lg">Apple security releases</a>
-    </div>
-  </div>
 
 
-<script>
-    document.addEventListener('DOMContentLoaded', async() => {
-        // Fetch and set configData before proceeding
-        configData = await fetchConfigData();
-        if (configData) {
-            const orderedData = orderSoftwareReleases(configData);
-            createTabs(orderedData); // Now configData is available for use within createTabs
+    <script>
+        document.addEventListener('DOMContentLoaded', async () => {
+            // Fetch and set configData before proceeding
+            configData = await fetchConfigData();
+            if (configData) {
+                const orderedData = orderSoftwareReleases(configData);
+                createTabs(orderedData); // Now configData is available for use within createTabs
 
-            const themeToggleBtn = document.getElementById('theme-toggle');
-            themeToggleBtn.addEventListener('click', toggleTheme);
-            setInitialTheme();
-            initializeCVEFiltering(); // Assuming this function does not directly depend on configData
-        } else {
-            console.error('Failed to load configuration data.');
-        }
-    });
-
-    async function fetchConfigData() {
-        try {
-            const response = await fetch('./config.json');
-            if (!response.ok) {
-                throw new Error(`Failed to fetch config data: HTTP status ${response.status}`);
+                const themeToggleBtn = document.getElementById('theme-toggle');
+                themeToggleBtn.addEventListener('click', toggleTheme);
+                setInitialTheme();
+                initializeCVEFiltering(); // Assuming this function does not directly depend on configData
+            } else {
+                console.error('Failed to load configuration data.');
             }
-            return await response.json();
-        } catch (error) {
-            console.error('Error fetching configuration:', error);
-            return null; // Return null to indicate failure
+        });
+
+        async function fetchConfigData() {
+            try {
+                const response = await fetch('./config.json');
+                if (!response.ok) {
+                    throw new Error(`Failed to fetch config data: HTTP status ${response.status}`);
+                }
+                return await response.json();
+            } catch (error) {
+                console.error('Error fetching configuration:', error);
+                return null; // Return null to indicate failure
+            }
         }
-    }
 
         async function createTabs(orderedData) {
-        const tabsContainer = document.getElementById('tabs');
-        tabsContainer.innerHTML = '';
-        const activeTabId = localStorage.getItem('activeTabId');
+            const tabsContainer = document.getElementById('tabs');
+            tabsContainer.innerHTML = '';
+            const activeTabId = localStorage.getItem('activeTabId');
 
-        orderedData.forEach(software => {
-            const button = document.createElement('button');
-            const softwareName = software.osType === 'iOS' ? `iOS ${software.name}` : software.name;
-            button.textContent = softwareName;
-            button.dataset.id = software.id;
-            button.className = getClassNames(software.id.toString() === activeTabId);
-            button.addEventListener('click', async () => {
-                setActiveTab(button);
-                const dataFeedPath = configData.globalSettings.dataFeedFiles[software.osType];
-                if (dataFeedPath) {
-                    await fetchData(`./${dataFeedPath}`, software.osType, softwareName);
-                } else {
-                    console.error("Data feed path not found for osType:", software.osType);
+            orderedData.forEach(software => {
+                const button = document.createElement('button');
+                const softwareName = software.osType === 'iOS' ? `iOS ${software.name}` : software.name;
+                button.textContent = softwareName;
+                button.dataset.id = software.id;
+                button.className = getClassNames(software.id.toString() === activeTabId);
+                button.addEventListener('click', async () => {
+                    setActiveTab(button);
+                    const dataFeedPath = configData.globalSettings.dataFeedFiles[software.osType];
+                    if (dataFeedPath) {
+                        await fetchData(`./${dataFeedPath}`, software.osType, softwareName);
+                    } else {
+                        console.error("Data feed path not found for osType:", software.osType);
+                    }
+                    // Instead of a separate function, directly control the XProtect card visibility here
+                    requestAnimationFrame(() => {
+                        document.getElementById('xprotect-card').style.display = software.osType === 'iOS' ? 'none' : '';
+                    });
+                });
+                tabsContainer.appendChild(button);
+            });
+
+            const initialTab = tabsContainer.querySelector(`[data-id="${activeTabId}"]`) || tabsContainer.firstChild;
+            if (initialTab) initialTab.click();
+        }
+
+        function getClassNames(isActive) {
+            return `px-4 py-2 rounded-lg mr-2 font-medium transition duration-150 ease-in-out ${isActive ? 'bg-indigo-600 text-white dark:bg-indigo-500' : 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300'} hover:bg-indigo-500 dark:hover:bg-indigo-400`;
+        }
+
+        function setActiveTab(activeTab) {
+            document.querySelectorAll('#tabs button').forEach(btn => {
+                btn.className = getClassNames(false); // Reset all to inactive state
+            });
+            activeTab.className = getClassNames(true); // Set active state
+            localStorage.setItem('activeTabId', activeTab.dataset.id); // Save active tab ID
+        }
+
+        async function fetchData(dataFeedPath, osType, osVersionName) {
+            try {
+                // Correcting the file path construction
+                const fullPath = `./v1/${dataFeedPath}`; // Assuming dataFeedPath is correctly provided from config
+                console.log("Full Path:", fullPath);
+
+                const response = await fetch(fullPath);
+                if (!response.ok) {
+                    throw new Error(`Failed to fetch data from ${fullPath}: ${response.statusText}`);
                 }
-                // Instead of a separate function, directly control the XProtect card visibility here
-                requestAnimationFrame(() => {
-                document.getElementById('xprotect-card').style.display = software.osType === 'iOS' ? 'none' : '';
-            });
-            });
-            tabsContainer.appendChild(button);
-        });
+                const data = await response.json();
 
-        const initialTab = tabsContainer.querySelector(`[data-id="${activeTabId}"]`) || tabsContainer.firstChild;
-        if (initialTab) initialTab.click();
-    }
+                // Adjusting the version name matching logic
+                // For iOS, we're stripping out non-numeric characters to match against version numbers like "17"
+                const versionNameFormatted = osType.toLowerCase() === 'ios' ?
+                    osVersionName.replace(/[^\d]/g, '') :
+                    osVersionName;
 
-    function getClassNames(isActive) {
-        return `px-4 py-2 rounded-lg mr-2 font-medium transition duration-150 ease-in-out ${isActive ? 'bg-indigo-600 text-white dark:bg-indigo-500' : 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300'} hover:bg-indigo-500 dark:hover:bg-indigo-400`;
-    }
+                console.log("Version Name Formatted:", versionNameFormatted);
 
-    function setActiveTab(activeTab) {
-        document.querySelectorAll('#tabs button').forEach(btn => {
-            btn.className = getClassNames(false); // Reset all to inactive state
-        });
-        activeTab.className = getClassNames(true); // Set active state
-        localStorage.setItem('activeTabId', activeTab.dataset.id); // Save active tab ID
-    }
+                // Attempting to find the specific version data
+                const specificVersionData = data.OSVersions.find(version => {
+                    // For iOS, we're directly comparing the cleaned version number
+                    return osType.toLowerCase() === 'ios' ?
+                        version.OSVersion === versionNameFormatted :
+                        version.OSVersion.toLowerCase().includes(versionNameFormatted.toLowerCase());
+                });
 
-    async function fetchData(dataFeedPath, osType, osVersionName) {
-        try {
-            // Correcting the file path construction
-            const fullPath = `./v1/${dataFeedPath}`; // Assuming dataFeedPath is correctly provided from config
-            console.log("Full Path:", fullPath);
-
-            const response = await fetch(fullPath);
-            if (!response.ok) {
-                throw new Error(`Failed to fetch data from ${fullPath}: ${response.statusText}`);
+                if (specificVersionData) {
+                    console.log("Found specific OS version data:", specificVersionData);
+                    // Pass InstallationApps directly along with specific version data and osType
+                    updateUIWithOSData(specificVersionData, osType, data, data.InstallationApps);
+                } else {
+                    console.error(`Specific OS version data not found for: ${osVersionName}`);
+                    // Optionally handle fallback here
+                }
+            } catch (error) {
+                console.error('Error in fetchData:', error);
             }
-            const data = await response.json();
+        }
 
-            // Adjusting the version name matching logic
-            // For iOS, we're stripping out non-numeric characters to match against version numbers like "17"
-            const versionNameFormatted = osType.toLowerCase() === 'ios' ?
-                osVersionName.replace(/[^\d]/g, '') :
-                osVersionName;
-
-            console.log("Version Name Formatted:", versionNameFormatted);
-
-            // Attempting to find the specific version data
-            const specificVersionData = data.OSVersions.find(version => {
-                // For iOS, we're directly comparing the cleaned version number
-                return osType.toLowerCase() === 'ios' ?
-                    version.OSVersion === versionNameFormatted :
-                    version.OSVersion.toLowerCase().includes(versionNameFormatted.toLowerCase());
+        function orderSoftwareReleases(configData) {
+            const {
+                softwareReleases,
+                globalSettings: {
+                    buttonOrder
+                }
+            } = configData;
+            // Map to get order index for OS types
+            const orderIndex = buttonOrder.reduce((acc, osType, index) => ({
+                ...acc,
+                [osType]: index
+            }), {});
+            // Sort by OS type order, then by id within each type
+            return softwareReleases.sort((a, b) => {
+                const typeOrderDiff = orderIndex[a.osType] - orderIndex[b.osType];
+                if (typeOrderDiff !== 0) return typeOrderDiff;
+                // Assuming 'id' is numeric and directly comparable
+                return a.id - b.id;
             });
+        }
 
-            if (specificVersionData) {
-            console.log("Found specific OS version data:", specificVersionData);
-            // Pass InstallationApps directly along with specific version data and osType
-            updateUIWithOSData(specificVersionData, osType, data, data.InstallationApps);
+        function updateUIWithOSData(specificVersionData, osType, fullData, installationApps) {
+            // Update the "Last Checked" and "Machine Readable Feed" sections
+            document.getElementById('last-checked').innerHTML = `Last checked: <span class="text-indigo-700 dark:text-indigo-300">${fullData.LastCheck}</span>`;
+            const fullPath = `v1/${osType}_data_feed.json`;
+            document.getElementById('machine-readable-feed').innerHTML = `Machine readable feed: <a href="${createSafeLink('v1/' + osType.toLowerCase() + '_data_feed.json')}" class="text-blue-600 hover:text-blue-400 dark:text-yellow-500 dark:hover:text-yellow-300">v1/${osType.toLowerCase()}_data_feed.json</a>`;
+
+            // Populate the version card with specific version data and installation apps
+            populateVersionCard(specificVersionData, osType, installationApps);
+
+            // Populate security releases if available
+            if (specificVersionData.SecurityReleases) {
+                populateSecurityReleases(specificVersionData.SecurityReleases, osType);
+            }
+
+            // Determine and display OS version links if applicable
+            const osVersion = determineOSVersion(specificVersionData, osType);
+            if (osVersion) {
+                fetchAndDisplayOSLinks(osType, osVersion);
             } else {
-                console.error(`Specific OS version data not found for: ${osVersionName}`);
-                // Optionally handle fallback here
+                console.error("Unable to determine OS version for linking.");
             }
-        } catch (error) {
-            console.error('Error in fetchData:', error);
-        }
-    }
 
-    function orderSoftwareReleases(configData) {
-        const {
-            softwareReleases,
-            globalSettings: {
-                buttonOrder
+            // Populate XProtect data if available and applicable to macOS, otherwise clear the XProtect card
+            if (osType.toLowerCase() === 'macos' && fullData.XProtectPayloads && fullData.XProtectPlistConfigData) {
+                populateXProtectCard(fullData.XProtectPlistConfigData, fullData.XProtectPayloads);
+            } else {
+                // Clear the XProtect card content for non-macOS OS types
+                document.getElementById('xprotect-card').innerHTML = '';
             }
-        } = configData;
-        // Map to get order index for OS types
-        const orderIndex = buttonOrder.reduce((acc, osType, index) => ({
-            ...acc,
-            [osType]: index
-        }), {});
-        // Sort by OS type order, then by id within each type
-        return softwareReleases.sort((a, b) => {
-            const typeOrderDiff = orderIndex[a.osType] - orderIndex[b.osType];
-            if (typeOrderDiff !== 0) return typeOrderDiff;
-            // Assuming 'id' is numeric and directly comparable
-            return a.id - b.id;
-        });
-    }
 
-    function updateUIWithOSData(specificVersionData, osType, fullData, installationApps) {
-        // Update the "Last Checked" and "Machine Readable Feed" sections
-        document.getElementById('last-checked').innerHTML = `Last checked: <span class="text-indigo-700 dark:text-indigo-300">${fullData.LastCheck}</span>`;
-        const fullPath = `v1/${osType}_data_feed.json`;
-        document.getElementById('machine-readable-feed').innerHTML = `Machine readable feed: <a href="${createSafeLink('v1/' + osType.toLowerCase() + '_data_feed.json')}" class="text-blue-600 hover:text-blue-400 dark:text-yellow-500 dark:hover:text-yellow-300">v1/${osType.toLowerCase()}_data_feed.json</a>`;
-
-        // Populate the version card with specific version data and installation apps
-        populateVersionCard(specificVersionData, osType, installationApps);
-
-        // Populate security releases if available
-        if (specificVersionData.SecurityReleases) {
-            populateSecurityReleases(specificVersionData.SecurityReleases, osType);
+            // Initialize CVE filtering for security releases
+            initializeCVEFiltering();
         }
 
-        // Determine and display OS version links if applicable
-        const osVersion = determineOSVersion(specificVersionData, osType);
-        if (osVersion) {
-            fetchAndDisplayOSLinks(osType, osVersion);
-        } else {
-            console.error("Unable to determine OS version for linking.");
+        function toggleTheme() {
+            const isDark = document.documentElement.classList.toggle('dark');
+            localStorage.setItem('theme', isDark ? 'dark' : 'light');
+            updateThemeIcon();
         }
 
-        // Populate XProtect data if available and applicable to macOS, otherwise clear the XProtect card
-        if (osType.toLowerCase() === 'macos' && fullData.XProtectPayloads && fullData.XProtectPlistConfigData) {
-            populateXProtectCard(fullData.XProtectPlistConfigData, fullData.XProtectPayloads);
-        } else {
-            // Clear the XProtect card content for non-macOS OS types
-            document.getElementById('xprotect-card').innerHTML = '';
+        function setInitialTheme() {
+            const isDarkMode = localStorage.getItem('theme') === 'dark' || (window.matchMedia('(prefers-color-scheme: dark)').matches && !localStorage.getItem('theme'));
+            document.documentElement.classList.toggle('dark', isDarkMode);
+            updateThemeIcon();
         }
 
-        // Initialize CVE filtering for security releases
-        initializeCVEFiltering();
-    }
-
-    function toggleTheme() {
-        const isDark = document.documentElement.classList.toggle('dark');
-        localStorage.setItem('theme', isDark ? 'dark' : 'light');
-        updateThemeIcon();
-    }
-
-    function setInitialTheme() {
-        const isDarkMode = localStorage.getItem('theme') === 'dark' || (window.matchMedia('(prefers-color-scheme: dark)').matches && !localStorage.getItem('theme'));
-        document.documentElement.classList.toggle('dark', isDarkMode);
-        updateThemeIcon();
-    }
-
-    function updateThemeIcon() {
-        const themeToggleDarkIcon = document.getElementById('theme-toggle-dark-icon');
-        const themeToggleLightIcon = document.getElementById('theme-toggle-light-icon');
-        const isDarkMode = document.documentElement.classList.contains('dark');
-        themeToggleDarkIcon.classList.toggle('hidden', !isDarkMode);
-        themeToggleLightIcon.classList.toggle('hidden', isDarkMode);
-    }
-
-    function determineOSVersion(osData, osType) {
-        // Ensure osType is correctly formatted
-        const type = osType.toLowerCase();
-        // Use the 'OSVersion' property since 'VersionName' does not exist in the provided data
-        const osVersion = osData.OSVersion;
-        if (!osVersion) {
-            console.warn(`OS version not found for ${osType} in provided data:`, osData);
-            return 'Unknown Version'; // Return a placeholder or handle this scenario as needed
+        function updateThemeIcon() {
+            const themeToggleDarkIcon = document.getElementById('theme-toggle-dark-icon');
+            const themeToggleLightIcon = document.getElementById('theme-toggle-light-icon');
+            const isDarkMode = document.documentElement.classList.contains('dark');
+            themeToggleDarkIcon.classList.toggle('hidden', !isDarkMode);
+            themeToggleLightIcon.classList.toggle('hidden', isDarkMode);
         }
-        // Assuming the OS version naming convention is consistent and does not require additional formatting
-        // Directly return the OSVersion value for both macOS and iOS, or adjust formatting as needed
-        return osVersion;
-    }
 
-    function getImageName(osData, osType) { // osType is added as a parameter
-        let imageName = "default.png"; // Default image name
-        if (osData && osData.OSVersion) {
-            const osVersionParts = osData.OSVersion.split(' ');
-            console.log("OS Version Parts:", osVersionParts);
-            // Handle macOS and iOS differently
-            if (osType.toLowerCase() === "macos") {
-                // Assuming the name directly follows "macOS"
-                const osName = osVersionParts[0];
-                imageName = `${osName}.png`; // Constructs image filename as "Ventura.png"
-            } else if (osType.toLowerCase() === "ios") {
-                // For iOS, assuming the version number directly follows "iOS"
-                const iosVersion = osVersionParts.join('_');
-                imageName = `ios_${iosVersion}.png`; // Constructs image filename as "ios_17.png"
+        function determineOSVersion(osData, osType) {
+            // Ensure osType is correctly formatted
+            const type = osType.toLowerCase();
+            // Use the 'OSVersion' property since 'VersionName' does not exist in the provided data
+            const osVersion = osData.OSVersion;
+            if (!osVersion) {
+                console.warn(`OS version not found for ${osType} in provided data:`, osData);
+                return 'Unknown Version'; // Return a placeholder or handle this scenario as needed
             }
-        }
-        return imageName; // Return the constructed image name or the default
-    }
-
-
-    function populateVersionCard(osData, osType, installationApps) {
-        const versionCardContainer = document.getElementById('version-card');
-        if (!versionCardContainer || !osData || !osData.Latest) {
-            console.error("Version card data is missing or empty.");
-            return;
+            // Assuming the OS version naming convention is consistent and does not require additional formatting
+            // Directly return the OSVersion value for both macOS and iOS, or adjust formatting as needed
+            return osVersion;
         }
 
-        const { OSVersion, Latest, ForkedBuilds } = osData;
-        const currentDateString = new Date().toISOString().split('T')[0];
+        function getImageName(osData, osType) { // osType is added as a parameter
+            let imageName = "default.png"; // Default image name
+            if (osData && osData.OSVersion) {
+                const osVersionParts = osData.OSVersion.split(' ');
+                console.log("OS Version Parts:", osVersionParts);
+                // Handle macOS and iOS differently
+                if (osType.toLowerCase() === "macos") {
+                    // Assuming the name directly follows "macOS"
+                    const osName = osVersionParts[0];
+                    imageName = `${osName}.png`; // Constructs image filename as "Ventura.png"
+                } else if (osType.toLowerCase() === "ios") {
+                    // For iOS, assuming the version number directly follows "iOS"
+                    const iosVersion = osVersionParts.join('_');
+                    imageName = `ios_${iosVersion}.png`; // Constructs image filename as "ios_17.png"
+                }
+            }
+            return imageName; // Return the constructed image name or the default
+        }
 
-        let forkedBuildHtml = '';
-        // Ensure ForkedBuilds is an array and iterate over it
-        if (Array.isArray(ForkedBuilds)) {
-            ForkedBuilds.forEach(forkedBuild => {
-                // Check if the current model is included in the forked build's Models array
-                if (forkedBuild.Models.includes('Mac17,7') &&  // Example: Adjust 'Mac17,7' to dynamically match required models
-                    forkedBuild.ProductVersion === Latest.ProductVersion &&
-                    new Date(forkedBuild.EffectiveUntil) >= new Date(currentDateString)) {
-                    forkedBuildHtml += `
+
+        function populateVersionCard(osData, osType, installationApps) {
+            const versionCardContainer = document.getElementById('version-card');
+            if (!versionCardContainer || !osData || !osData.Latest) {
+                console.error("Version card data is missing or empty.");
+                return;
+            }
+
+            const { OSVersion, Latest, ForkedBuilds } = osData;
+            const currentDateString = new Date().toISOString().split('T')[0];
+
+            let forkedBuildHtml = '';
+            // Ensure ForkedBuilds is an array and iterate over it
+            if (Array.isArray(ForkedBuilds)) {
+                ForkedBuilds.forEach(forkedBuild => {
+                    // Check if the current model is included in the forked build's Models array
+                    if (forkedBuild.Models.includes('Mac17,7') &&  // Example: Adjust 'Mac17,7' to dynamically match required models
+                        forkedBuild.ProductVersion === Latest.ProductVersion &&
+                        new Date(forkedBuild.EffectiveUntil) >= new Date(currentDateString)) {
+                        forkedBuildHtml += `
                         <div class="forked-build mt-4">
                             <h4 class=" text-sm text-gray-600 dark:text-gray-400">Forked Build: ${forkedBuild.Build}</h4>
                             <p class="text-sm text-gray-600 dark:text-gray-400">Hardware: ${forkedBuild.Models}</p>
                             <p class="text-sm text-gray-600 dark:text-gray-400">${forkedBuild.AdditionalDetails}</p>
                         </div>
                     `;
-                }
-            });
-        }
+                    }
+                });
+            }
 
-        const imageName = getImageName(osData, osType);
-        let latestUMAHtml = generateLatestUMAHtml(installationApps, Latest.ProductVersion);  // Assuming this is a separate function handling the logic
+            const imageName = getImageName(osData, osType);
+            let latestUMAHtml = generateLatestUMAHtml(installationApps, Latest.ProductVersion);  // Assuming this is a separate function handling the logic
 
-        // Build the HTML content for the OS section
-        const osSectionHTML = `<h3 class="text-lg leading-6 font-semibold text-indigo-700 dark:text-indigo-400">${osType} ${OSVersion}</h3>
+            // Build the HTML content for the OS section
+            const osSectionHTML = `<h3 class="text-lg leading-6 font-semibold text-indigo-700 dark:text-indigo-400">${osType} ${OSVersion}</h3>
         <div><strong>Last released version:</strong> ${Latest.ProductVersion}</div>
         <div class="mt-2 max-w-xl text-sm text-gray-600 dark:text-gray-400">
             ${latestUMAHtml}
@@ -391,41 +417,41 @@
             <ul class="links-list" data-os-version="${OSVersion}"></ul>
         </div>`;
 
-        versionCardContainer.innerHTML = osSectionHTML; // Inject the content into the version card container
-        attachCopyEventListeners(); // Attach event listeners for any interactive elements
-    }
-
-
-    function generateLatestUMAHtml(installationApps, productVersion) {
-    let umaDetails = null;
-
-    console.log("Installation for product:", productVersion);
-    console.log("Available installationApps data:", installationApps);
-
-        if (installationApps) {
-            // Debugging output to check the versions in LatestUMA and AllPreviousUMA
-            if (installationApps.LatestUMA) {
-                console.log("LatestUMA version:", installationApps.LatestUMA.version);
-            }
-            if (installationApps.AllPreviousUMA) {
-                installationApps.AllPreviousUMA.forEach(uma => console.log("AllPreviousUMA version:", uma.version));
-            }
-
-            // Check if the current productVersion matches LatestUMA
-            if (installationApps.LatestUMA && installationApps.LatestUMA.version === productVersion) {
-                umaDetails = installationApps.LatestUMA;
-            }
-
-            // If not found in LatestUMA, check each item in AllPreviousUMA
-            if (!umaDetails && installationApps.AllPreviousUMA) {
-                umaDetails = installationApps.AllPreviousUMA.find(uma => uma.version === productVersion);
-            }
+            versionCardContainer.innerHTML = osSectionHTML; // Inject the content into the version card container
+            attachCopyEventListeners(); // Attach event listeners for any interactive elements
         }
 
-        // Generate HTML if umaDetails is found
-        if (umaDetails) {
-            const { title, version, build, apple_slug, url } = umaDetails;
-            return `
+
+        function generateLatestUMAHtml(installationApps, productVersion) {
+            let umaDetails = null;
+
+            console.log("Installation for product:", productVersion);
+            console.log("Available installationApps data:", installationApps);
+
+            if (installationApps) {
+                // Debugging output to check the versions in LatestUMA and AllPreviousUMA
+                if (installationApps.LatestUMA) {
+                    console.log("LatestUMA version:", installationApps.LatestUMA.version);
+                }
+                if (installationApps.AllPreviousUMA) {
+                    installationApps.AllPreviousUMA.forEach(uma => console.log("AllPreviousUMA version:", uma.version));
+                }
+
+                // Check if the current productVersion matches LatestUMA
+                if (installationApps.LatestUMA && installationApps.LatestUMA.version === productVersion) {
+                    umaDetails = installationApps.LatestUMA;
+                }
+
+                // If not found in LatestUMA, check each item in AllPreviousUMA
+                if (!umaDetails && installationApps.AllPreviousUMA) {
+                    umaDetails = installationApps.AllPreviousUMA.find(uma => uma.version === productVersion);
+                }
+            }
+
+            // Generate HTML if umaDetails is found
+            if (umaDetails) {
+                const { title, version, build, apple_slug, url } = umaDetails;
+                return `
                 <div class="uma-details">
                     <div class="mt-2 max-w-xl text-sm text-gray-600 dark:text-gray-400">
                         <p><strong>Installer Package:</strong>
@@ -442,119 +468,119 @@
                     </div>
                 </div>
             `;
-        } else {
-            console.error("No matching UMA details found for version:", productVersion);
-            return ''; // Return an empty string if no data matches
+            } else {
+                console.error("No matching UMA details found for version:", productVersion);
+                return ''; // Return an empty string if no data matches
+            }
         }
-    }
 
 
-    function copyToClipboard() {
-        // Assuming `this` context or binding in HTML
-        const url = this.getAttribute('data-url');
-        navigator.clipboard.writeText(url).then(() => {
-            alert('URL copied to clipboard!');
-        }).catch(err => {
-            console.error('Error in copying text: ', err);
-        });
-    }
+        function copyToClipboard() {
+            // Assuming `this` context or binding in HTML
+            const url = this.getAttribute('data-url');
+            navigator.clipboard.writeText(url).then(() => {
+                alert('URL copied to clipboard!');
+            }).catch(err => {
+                console.error('Error in copying text: ', err);
+            });
+        }
 
 
-    function attachCopyEventListeners() {
-        document.querySelectorAll('.copy-btn').forEach(button => {
-            button.addEventListener('click', function() {
-                const urlToCopy = this.getAttribute('data-url');
-                navigator.clipboard.writeText(urlToCopy).then(() => {
-                    alert('URL copied to clipboard!');
-                }, (err) => {
-                    console.error('Error copying URL to clipboard:', err);
+        function attachCopyEventListeners() {
+            document.querySelectorAll('.copy-btn').forEach(button => {
+                button.addEventListener('click', function () {
+                    const urlToCopy = this.getAttribute('data-url');
+                    navigator.clipboard.writeText(urlToCopy).then(() => {
+                        alert('URL copied to clipboard!');
+                    }, (err) => {
+                        console.error('Error copying URL to clipboard:', err);
+                    });
                 });
             });
-        });
-    }
-
-    function fetchAndDisplayOSLinks(osType, osFullVersion) {
-        console.log(`Fetching links for ${osType}, version: ${osFullVersion}`); // Use osFullVersion for logging
-        fetch('essential_links.json')
-            .then(response => {
-                if (!response.ok) throw new Error('Network response was not OK');
-                return response.json();
-            })
-            .then(data => {
-                console.log("Fetched data:", data);
-                // No need to split osFullVersion; it should directly match the JSON structure
-                const versionKey = osType === 'macOS' ? osFullVersion.split(' ')[0] : osFullVersion;
-                const commonLinks = data.Common || {};
-                const specificLinks = data[osType] && data[osType][versionKey] ? data[osType][versionKey] : {};
-                const mergedLinks = {
-                    ...specificLinks,
-                    ...commonLinks
-                };
-                console.log(`Merged Links for ${osType} ${versionKey}:`, mergedLinks);
-                if (Object.keys(mergedLinks).length) {
-                    console.log(`Displaying links for ${osType} ${versionKey}:`, mergedLinks);
-                    populateOSLinks(mergedLinks, osFullVersion); // Pass osFullVersion to align with your HTML structure
-                } else {
-                    console.error(`No links found for ${osType} ${versionKey}`);
-                }
-            })
-            .catch(error => console.error('Error fetching essential links:', error));
-    }
-
-    function populateOSLinks(links, osFullVersion) {
-        const linksList = document.querySelector(`.links-list[data-os-version='${osFullVersion}']`);
-        if (!linksList) {
-            console.error(`No links list found for OS version: ${osFullVersion}`);
-            return;
         }
 
-        linksList.classList.add('max-w-xl', 'text-sm');
-        linksList.innerHTML = ''; // Clear the list before repopulating it
-
-        Object.entries(links).forEach(([key, url]) => {
-            // Sanitize the URL before using it in the href attribute
-            const sanitizedUrl = createSafeLink(url);
-
-            // Create a list item and anchor element for each link
-            const listItem = document.createElement('li');
-            const linkElement = document.createElement('a');
-            linkElement.href = sanitizedUrl; // Use the sanitized URL
-            linkElement.textContent = key; // Set the link text
-            linkElement.setAttribute('target', '_blank');
-            linkElement.classList.add('text-blue-600', 'hover:text-blue-400', 'dark:text-yellow-500', 'dark:hover:text-yellow-300');
-
-            // Append the anchor element to the list item, then append the list item to the list
-            listItem.appendChild(linkElement);
-            linksList.appendChild(listItem);
-        });
-    }
-
-
-
-    function populateXProtectCard(XProtectPlistConfigData, XProtectPayloads) {
-        console.log("Populating XProtect Card", {
-            XProtectPlistConfigData,
-            XProtectPayloads
-        });
-        const xProtectCardContainer = document.getElementById('xprotect-card');
-        if (!xProtectCardContainer) {
-            console.error('XProtect card container not found.');
-            return;
+        function fetchAndDisplayOSLinks(osType, osFullVersion) {
+            console.log(`Fetching links for ${osType}, version: ${osFullVersion}`); // Use osFullVersion for logging
+            fetch('essential_links.json')
+                .then(response => {
+                    if (!response.ok) throw new Error('Network response was not OK');
+                    return response.json();
+                })
+                .then(data => {
+                    console.log("Fetched data:", data);
+                    // No need to split osFullVersion; it should directly match the JSON structure
+                    const versionKey = osType === 'macOS' ? osFullVersion.split(' ')[0] : osFullVersion;
+                    const commonLinks = data.Common || {};
+                    const specificLinks = data[osType] && data[osType][versionKey] ? data[osType][versionKey] : {};
+                    const mergedLinks = {
+                        ...specificLinks,
+                        ...commonLinks
+                    };
+                    console.log(`Merged Links for ${osType} ${versionKey}:`, mergedLinks);
+                    if (Object.keys(mergedLinks).length) {
+                        console.log(`Displaying links for ${osType} ${versionKey}:`, mergedLinks);
+                        populateOSLinks(mergedLinks, osFullVersion); // Pass osFullVersion to align with your HTML structure
+                    } else {
+                        console.error(`No links found for ${osType} ${versionKey}`);
+                    }
+                })
+                .catch(error => console.error('Error fetching essential links:', error));
         }
-        // Extracting necessary data directly
-        const xProtectVersion = XProtectPlistConfigData["com.apple.XProtect"];
-        const xProtectAppVersion = XProtectPayloads["com.apple.XProtectFramework.XProtect"];
-        const xProtectPluginService = XProtectPayloads["com.apple.XprotectFramework.PluginService"];
-        const appReleaseDate = XProtectPayloads.ReleaseDate;
-        const plistReleaseDate = XProtectPlistConfigData.ReleaseDate;
 
-        const daysSinceAppRelease = Math.floor((new Date() - new Date(appReleaseDate)) / (1000 * 60 * 60 * 24));
-        const daysSincePlistRelease = Math.floor((new Date() - new Date(plistReleaseDate)) / (1000 * 60 * 60 * 24));
+        function populateOSLinks(links, osFullVersion) {
+            const linksList = document.querySelector(`.links-list[data-os-version='${osFullVersion}']`);
+            if (!linksList) {
+                console.error(`No links list found for OS version: ${osFullVersion}`);
+                return;
+            }
 
-        const xProtectInfoUrl = "https://support.apple.com/guide/security/protecting-against-malware-sec469d47bd8/web";
-        const sanitizedUrl = createSafeLink(xProtectInfoUrl); // Use createSafeLink to sanitize the URL
+            linksList.classList.add('max-w-xl', 'text-sm');
+            linksList.innerHTML = ''; // Clear the list before repopulating it
 
-        const xProtectCardHTML = `
+            Object.entries(links).forEach(([key, url]) => {
+                // Sanitize the URL before using it in the href attribute
+                const sanitizedUrl = createSafeLink(url);
+
+                // Create a list item and anchor element for each link
+                const listItem = document.createElement('li');
+                const linkElement = document.createElement('a');
+                linkElement.href = sanitizedUrl; // Use the sanitized URL
+                linkElement.textContent = key; // Set the link text
+                linkElement.setAttribute('target', '_blank');
+                linkElement.classList.add('text-blue-600', 'hover:text-blue-400', 'dark:text-yellow-500', 'dark:hover:text-yellow-300');
+
+                // Append the anchor element to the list item, then append the list item to the list
+                listItem.appendChild(linkElement);
+                linksList.appendChild(listItem);
+            });
+        }
+
+
+
+        function populateXProtectCard(XProtectPlistConfigData, XProtectPayloads) {
+            console.log("Populating XProtect Card", {
+                XProtectPlistConfigData,
+                XProtectPayloads
+            });
+            const xProtectCardContainer = document.getElementById('xprotect-card');
+            if (!xProtectCardContainer) {
+                console.error('XProtect card container not found.');
+                return;
+            }
+            // Extracting necessary data directly
+            const xProtectVersion = XProtectPlistConfigData["com.apple.XProtect"];
+            const xProtectAppVersion = XProtectPayloads["com.apple.XProtectFramework.XProtect"];
+            const xProtectPluginService = XProtectPayloads["com.apple.XprotectFramework.PluginService"];
+            const appReleaseDate = XProtectPayloads.ReleaseDate;
+            const plistReleaseDate = XProtectPlistConfigData.ReleaseDate;
+
+            const daysSinceAppRelease = Math.floor((new Date() - new Date(appReleaseDate)) / (1000 * 60 * 60 * 24));
+            const daysSincePlistRelease = Math.floor((new Date() - new Date(plistReleaseDate)) / (1000 * 60 * 60 * 24));
+
+            const xProtectInfoUrl = "https://support.apple.com/guide/security/protecting-against-malware-sec469d47bd8/web";
+            const sanitizedUrl = createSafeLink(xProtectInfoUrl); // Use createSafeLink to sanitize the URL
+
+            const xProtectCardHTML = `
         <h3 class="text-lg leading-6 font-semibold text-indigo-700 dark:text-indigo-400">XProtect data files</h3>
         <div><strong>Latest versions:</strong> ${xProtectAppVersion} | ${xProtectPluginService} | ${xProtectVersion}</div>
         <div class="mt-2 max-w-xl text-sm text-gray-600 dark:text-gray-400">
@@ -576,87 +602,87 @@
     </div>
     `;
 
-        xProtectCardContainer.innerHTML = xProtectCardHTML;
-    }
+            xProtectCardContainer.innerHTML = xProtectCardHTML;
+        }
 
-    function populateSecurityReleases(securityReleases, osType) {
-    const securityReleasesContainer = document.getElementById('security-releases');
-    // Clear previous contents
-    securityReleasesContainer.innerHTML = '';
+        function populateSecurityReleases(securityReleases, osType) {
+            const securityReleasesContainer = document.getElementById('security-releases');
+            // Clear previous contents
+            securityReleasesContainer.innerHTML = '';
 
-    const header = document.createElement('h2');
-    header.className = "text-2xl text-indigo-700 dark:text-yellow-500 font-semibold mb-4";
-    header.textContent = `${osType} Security Updates Overview`;
-    securityReleasesContainer.appendChild(header);
+            const header = document.createElement('h2');
+            header.className = "text-2xl text-indigo-700 dark:text-yellow-500 font-semibold mb-4";
+            header.textContent = `${osType} Security Updates Overview`;
+            securityReleasesContainer.appendChild(header);
 
-    securityReleases.forEach((release, index) => {
-        const section = document.createElement('div');
-        section.className = `${index > 0 ? 'border-t-2 border-gray-500 pt-4 mt-4' : ''} dark:border-gray-700`;
+            securityReleases.forEach((release, index) => {
+                const section = document.createElement('div');
+                section.className = `${index > 0 ? 'border-t-2 border-gray-500 pt-4 mt-4' : ''} dark:border-gray-700`;
 
-        const tooltipText = "Critical security updates included in this release. Please review for impact.";
-        const warningSign = release.SecurityInfo.startsWith('http') ? `<span class="text-yellow-400" title="${tooltipText}" aria-label="${tooltipText}"> ⚠️</span>` : '';
-        
-        const securityInfoHTML = release.SecurityInfo.startsWith('http') ?
-            `<a href="${createSafeLink(release.SecurityInfo)}" class="text-blue-600 hover:text-blue-400 dark:text-yellow-500 dark:hover:text-yellow-300 " target="_blank" aria-label="Security Information Link">${release.SecurityInfo}</a>` :
-            release.SecurityInfo;
+                const tooltipText = "Critical security updates included in this release. Please review for impact.";
+                const warningSign = release.SecurityInfo.startsWith('http') ? `<span class="text-yellow-400" title="${tooltipText}" aria-label="${tooltipText}"> ⚠️</span>` : '';
 
-            let cveLinksHTML = Object.keys(release.CVEs).map(cve => {
-                const cveOrgUrl = `https://www.cve.org/CVERecord?id=${cve}`;
-                const nvdUrl = `https://nvd.nist.gov/vuln/detail/${cve}`; // NVD URL
-                const isActivelyExploited = release.CVEs[cve]; // Active exploitation check
-                const cveStatusText = isActivelyExploited ? " (Actively Exploited)" : "";
-                const tooltipText = isActivelyExploited ? 
-                    `View CVE at CVE.org. Or use 'Command-click'/'Ctrl-click' to open in NVD records at ${nvdUrl}` : 
-                    `View CVE at CVE.org. Or use 'Command-click'/'Ctrl-click' to open in NVD records.`;
+                const securityInfoHTML = release.SecurityInfo.startsWith('http') ?
+                    `<a href="${createSafeLink(release.SecurityInfo)}" class="text-blue-600 hover:text-blue-400 dark:text-yellow-500 dark:hover:text-yellow-300 " target="_blank" aria-label="Security Information Link">${release.SecurityInfo}</a>` :
+                    release.SecurityInfo;
+
+                let cveLinksHTML = Object.keys(release.CVEs).map(cve => {
+                    const cveOrgUrl = `https://www.cve.org/CVERecord?id=${cve}`;
+                    const nvdUrl = `https://nvd.nist.gov/vuln/detail/${cve}`; // NVD URL
+                    const isActivelyExploited = release.CVEs[cve]; // Active exploitation check
+                    const cveStatusText = isActivelyExploited ? " (Actively Exploited)" : "";
+                    const tooltipText = isActivelyExploited ?
+                        `View CVE at CVE.org. Or use 'Command-click'/'Ctrl-click' to open in NVD records at ${nvdUrl}` :
+                        `View CVE at CVE.org. Or use 'Command-click'/'Ctrl-click' to open in NVD records.`;
                     const cveClass = isActivelyExploited ? "text-blue-600 hover:text-orange-700" : "text-blue-600 hover:text-blue-400";
-    const darkModeCveClass = isActivelyExploited ? "dark:text-yellow-500 dark:hover:text-orange-500" : "dark:text-yellow-500 dark:hover:text-yellow-300";
-                // Include data-nvd-url attribute
-                return `<a href="${cveOrgUrl}" data-cve class="${cveClass} ${darkModeCveClass}" target="_blank" data-nvd-url="${nvdUrl}" title="${tooltipText}">${cve}${cveStatusText}</a>`;
-            }).join(', ');
+                    const darkModeCveClass = isActivelyExploited ? "dark:text-yellow-500 dark:hover:text-orange-500" : "dark:text-yellow-500 dark:hover:text-yellow-300";
+                    // Include data-nvd-url attribute
+                    return `<a href="${cveOrgUrl}" data-cve class="${cveClass} ${darkModeCveClass}" target="_blank" data-nvd-url="${nvdUrl}" title="${tooltipText}">${cve}${cveStatusText}</a>`;
+                }).join(', ');
 
-            document.querySelectorAll('a[data-cve]').forEach(link => {
-            link.addEventListener('click', function(e) {
-                // Check for Command-click or Ctrl-click
-                if (e.metaKey || e.ctrlKey) {
-                    e.preventDefault(); // Prevent default link behavior
-                    const nvdUrl = this.getAttribute('data-nvd-url'); // Access NVD URL
-                    window.open(nvdUrl, '_blank'); // Open NVD URL in a new tab
-                }
-            });
-        });
+                document.querySelectorAll('a[data-cve]').forEach(link => {
+                    link.addEventListener('click', function (e) {
+                        // Check for Command-click or Ctrl-click
+                        if (e.metaKey || e.ctrlKey) {
+                            e.preventDefault(); // Prevent default link behavior
+                            const nvdUrl = this.getAttribute('data-nvd-url'); // Access NVD URL
+                            window.open(nvdUrl, '_blank'); // Open NVD URL in a new tab
+                        }
+                    });
+                });
 
-        const activelyExploitedCVEsHTML = release.ActivelyExploitedCVEs.length > 0 ?
-        `<p class="text-gray-600 dark:text-gray-400">Actively Exploited Vulnerabilities (KEV): ` +
-        release.ActivelyExploitedCVEs.map(cve => {
-            // Generating the NVD URL dynamically based on the CVE ID.
-            const nvdUrl = `https://nvd.nist.gov/vuln/detail/${cve}`;
-            // Assuming you have a way to fetch the Date Added and Due Date for each CVE
-            const dateAdded = "2024-03-06"; // Placeholder, replace with actual data retrieval logic
-            const dueDate = "2024-03-27"; // Placeholder, replace with actual data retrieval logic
-            // Updated tooltip text to guide users towards CISA for an overview or NVD for detailed records.
-            const tooltipText = `View CVE at CISA.gov. Or use 'Command-click'/'Ctrl-click' to open in NVD records. Date Added: ${dateAdded}, Due Date: ${dueDate}`;
-            // CISA URL for viewing the overview of the CVE.
-            const kevUrl = `https://www.cisa.gov/known-exploited-vulnerabilities-catalog?search_api_fulltext=${cve}`;
+                const activelyExploitedCVEsHTML = release.ActivelyExploitedCVEs.length > 0 ?
+                    `<p class="text-gray-600 dark:text-gray-400">Actively Exploited Vulnerabilities (KEV): ` +
+                    release.ActivelyExploitedCVEs.map(cve => {
+                        // Generating the NVD URL dynamically based on the CVE ID.
+                        const nvdUrl = `https://nvd.nist.gov/vuln/detail/${cve}`;
+                        // Assuming you have a way to fetch the Date Added and Due Date for each CVE
+                        const dateAdded = "2024-03-06"; // Placeholder, replace with actual data retrieval logic
+                        const dueDate = "2024-03-27"; // Placeholder, replace with actual data retrieval logic
+                        // Updated tooltip text to guide users towards CISA for an overview or NVD for detailed records.
+                        const tooltipText = `View CVE at CISA.gov. Or use 'Command-click'/'Ctrl-click' to open in NVD records. Date Added: ${dateAdded}, Due Date: ${dueDate}`;
+                        // CISA URL for viewing the overview of the CVE.
+                        const kevUrl = `https://www.cisa.gov/known-exploited-vulnerabilities-catalog?search_api_fulltext=${cve}`;
 
-            // Incorporate the fire emoji for actively exploited CVEs
-            return `<a href="${createSafeLink(kevUrl)}" data-cve data-nvd-url="${nvdUrl}" class="text-blue-600 dark:text-yellow-500 hover:text-orange-700 dark:hover:text-orange-500" target="_blank" title="${tooltipText}" aria-label="KEV Link ${cve}">
+                        // Incorporate the fire emoji for actively exploited CVEs
+                        return `<a href="${createSafeLink(kevUrl)}" data-cve data-nvd-url="${nvdUrl}" class="text-blue-600 dark:text-yellow-500 hover:text-orange-700 dark:hover:text-orange-500" target="_blank" title="${tooltipText}" aria-label="KEV Link ${cve}">
                         <span class="emoji highlight-active" title="Actively exploited">🔥 ${cve} </span>
                     </a>`;
-        }).join(', ') + `</p>` : '';
+                    }).join(', ') + `</p>` : '';
 
-        document.querySelectorAll('a[data-cve][data-nvd-url]').forEach(link => {
-            link.addEventListener('click', function(e) {
-                if (e.metaKey || e.ctrlKey) {
-                    e.preventDefault(); // Prevent the default action
-                    // Retrieve the NVD URL stored in the data attribute
-                    const nvdUrl = this.getAttribute('data-nvd-url');
-                    window.open(nvdUrl, '_blank'); // Open the NVD URL in a new tab
-                }
-            });
-        });
+                document.querySelectorAll('a[data-cve][data-nvd-url]').forEach(link => {
+                    link.addEventListener('click', function (e) {
+                        if (e.metaKey || e.ctrlKey) {
+                            e.preventDefault(); // Prevent the default action
+                            // Retrieve the NVD URL stored in the data attribute
+                            const nvdUrl = this.getAttribute('data-nvd-url');
+                            window.open(nvdUrl, '_blank'); // Open the NVD URL in a new tab
+                        }
+                    });
+                });
 
 
-            section.innerHTML = `
+                section.innerHTML = `
             <p class="mt-1 max-w-2xl text-sm text-gray-600 dark:text-gray-400">Release Date: ${formatDate(release.ReleaseDate)}${warningSign}</p>
             <h3 class="text-lg leading-6 font-medium text-indigo-700 dark:text-yellow-500">${release.UpdateName}</h3>
             <p class="text-gray-600 dark:text-gray-400">Security Info: ${securityInfoHTML}</p>
@@ -666,78 +692,79 @@
             <p class="mt-1 max-w-2xl text-sm text-gray-600 dark:text-gray-400">Days to Prev. Release: ${release.DaysSincePreviousRelease}</p>
             `;
 
-            securityReleasesContainer.appendChild(section);
-        });
-    }
-
-
-    function createSafeLink(url) {
-        // Create a temporary anchor (a) element
-        const tempAnchorElement = document.createElement('a');
-        // Set the href attribute to the provided URL
-        tempAnchorElement.href = url;
-        // Return the sanitized href attribute value
-        return tempAnchorElement.href;
-    }
-
-    function formatDate(dateString) {
-        const options = {
-            year: 'numeric',
-            month: 'long',
-            day: 'numeric'
-        };
-        return new Date(dateString).toLocaleDateString(undefined, options);
-    }
-
-    function initializeCVEFiltering() {
-        const searchInput = document.getElementById('searchInput');
-        searchInput.addEventListener('input', filterCVEs); // Setup the filter to respond to input
-        filterCVEs(); // Apply the filter immediately in case there's an initial search term
-    }
-
-    let hideNoMatches = false; // Default behavior is to hide OS versions with no matching CVEs
-
-    function filterCVEs() {
-        const searchTerm = document.getElementById('searchInput').value.trim().toLowerCase();
-        const securityReleasesContainer = document.getElementById('security-releases');
-        const releaseContainers = securityReleasesContainer.querySelectorAll('div');
-
-        if (!searchTerm) {
-            // Reset visibility for all CVE links and containers when search is cleared
-            resetSearchFiltering(releaseContainers);
-            return; // Exit early if there is no search term
+                securityReleasesContainer.appendChild(section);
+            });
         }
 
-        // Iterate over each release container
-        releaseContainers.forEach(container => {
-            let hasVisibleCVE = false; // Track if the container has any visible CVEs
-            const cveLinks = container.querySelectorAll('[data-cve]'); // Get all CVE links within the container
 
-            // Iterate over each CVE link to determine visibility
-            cveLinks.forEach(link => {
-                const match = link.textContent.toLowerCase().includes(searchTerm);
-                if (match) {
-                    link.classList.add('highlight-cve');
-                    hasVisibleCVE = true; // Indicate that the container has a matching CVE
-                } else {
-                    link.classList.remove('highlight-cve');
-                }
+        function createSafeLink(url) {
+            // Create a temporary anchor (a) element
+            const tempAnchorElement = document.createElement('a');
+            // Set the href attribute to the provided URL
+            tempAnchorElement.href = url;
+            // Return the sanitized href attribute value
+            return tempAnchorElement.href;
+        }
+
+        function formatDate(dateString) {
+            const options = {
+                year: 'numeric',
+                month: 'long',
+                day: 'numeric'
+            };
+            return new Date(dateString).toLocaleDateString(undefined, options);
+        }
+
+        function initializeCVEFiltering() {
+            const searchInput = document.getElementById('searchInput');
+            searchInput.addEventListener('input', filterCVEs); // Setup the filter to respond to input
+            filterCVEs(); // Apply the filter immediately in case there's an initial search term
+        }
+
+        let hideNoMatches = false; // Default behavior is to hide OS versions with no matching CVEs
+
+        function filterCVEs() {
+            const searchTerm = document.getElementById('searchInput').value.trim().toLowerCase();
+            const securityReleasesContainer = document.getElementById('security-releases');
+            const releaseContainers = securityReleasesContainer.querySelectorAll('div');
+
+            if (!searchTerm) {
+                // Reset visibility for all CVE links and containers when search is cleared
+                resetSearchFiltering(releaseContainers);
+                return; // Exit early if there is no search term
+            }
+
+            // Iterate over each release container
+            releaseContainers.forEach(container => {
+                let hasVisibleCVE = false; // Track if the container has any visible CVEs
+                const cveLinks = container.querySelectorAll('[data-cve]'); // Get all CVE links within the container
+
+                // Iterate over each CVE link to determine visibility
+                cveLinks.forEach(link => {
+                    const match = link.textContent.toLowerCase().includes(searchTerm);
+                    if (match) {
+                        link.classList.add('highlight-cve');
+                        hasVisibleCVE = true; // Indicate that the container has a matching CVE
+                    } else {
+                        link.classList.remove('highlight-cve');
+                    }
+                });
+
+                // Adjust the visibility of the container based on whether it has visible CVEs
+                container.style.display = hasVisibleCVE ? '' : 'none';
             });
+        }
 
-            // Adjust the visibility of the container based on whether it has visible CVEs
-            container.style.display = hasVisibleCVE ? '' : 'none';
-        });
-    }
-
-    function resetSearchFiltering(releaseContainers) {
-        // Function to reset the visibility of all CVE links and their containers
-        releaseContainers.forEach(container => {
-            container.style.display = ''; // Show all containers
-            const cveLinks = container.querySelectorAll('[data-cve]');
-            cveLinks.forEach(link => link.classList.remove('highlight-cve')); // Remove highlight from all CVE links
-        });
-    }
-</script>
+        function resetSearchFiltering(releaseContainers) {
+            // Function to reset the visibility of all CVE links and their containers
+            releaseContainers.forEach(container => {
+                container.style.display = ''; // Show all containers
+                const cveLinks = container.querySelectorAll('[data-cve]');
+                cveLinks.forEach(link => link.classList.remove('highlight-cve')); // Remove highlight from all CVE links
+            });
+        }
+    </script>
 
 </body>
+
 </html>

--- a/main.css
+++ b/main.css
@@ -44,7 +44,7 @@ html,
   -moz-tab-size: 4;
   /* 3 */
   -o-tab-size: 4;
-     tab-size: 4;
+  tab-size: 4;
   /* 3 */
   font-family: ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   /* 4 */
@@ -89,7 +89,7 @@ Add the correct text decoration in Chrome, Edge, and Safari.
 
 abbr:where([title]) {
   -webkit-text-decoration: underline dotted;
-          text-decoration: underline dotted;
+  text-decoration: underline dotted;
 }
 
 /*
@@ -378,7 +378,8 @@ textarea {
 2. Set the default placeholder color to the user's configured gray 400 color.
 */
 
-input::-moz-placeholder, textarea::-moz-placeholder {
+input::-moz-placeholder,
+textarea::-moz-placeholder {
   opacity: 1;
   /* 1 */
   color: #9ca3af;
@@ -446,7 +447,9 @@ video {
   display: none;
 }
 
-*, ::before, ::after {
+*,
+::before,
+::after {
   --tw-border-spacing-x: 0;
   --tw-border-spacing-y: 0;
   --tw-translate-x: 0;
@@ -456,19 +459,19 @@ video {
   --tw-skew-y: 0;
   --tw-scale-x: 1;
   --tw-scale-y: 1;
-  --tw-pan-x:  ;
-  --tw-pan-y:  ;
-  --tw-pinch-zoom:  ;
+  --tw-pan-x: ;
+  --tw-pan-y: ;
+  --tw-pinch-zoom: ;
   --tw-scroll-snap-strictness: proximity;
-  --tw-gradient-from-position:  ;
-  --tw-gradient-via-position:  ;
-  --tw-gradient-to-position:  ;
-  --tw-ordinal:  ;
-  --tw-slashed-zero:  ;
-  --tw-numeric-figure:  ;
-  --tw-numeric-spacing:  ;
-  --tw-numeric-fraction:  ;
-  --tw-ring-inset:  ;
+  --tw-gradient-from-position: ;
+  --tw-gradient-via-position: ;
+  --tw-gradient-to-position: ;
+  --tw-ordinal: ;
+  --tw-slashed-zero: ;
+  --tw-numeric-figure: ;
+  --tw-numeric-spacing: ;
+  --tw-numeric-fraction: ;
+  --tw-ring-inset: ;
   --tw-ring-offset-width: 0px;
   --tw-ring-offset-color: #fff;
   --tw-ring-color: rgb(59 130 246 / 0.5);
@@ -476,28 +479,28 @@ video {
   --tw-ring-shadow: 0 0 #0000;
   --tw-shadow: 0 0 #0000;
   --tw-shadow-colored: 0 0 #0000;
-  --tw-blur:  ;
-  --tw-brightness:  ;
-  --tw-contrast:  ;
-  --tw-grayscale:  ;
-  --tw-hue-rotate:  ;
-  --tw-invert:  ;
-  --tw-saturate:  ;
-  --tw-sepia:  ;
-  --tw-drop-shadow:  ;
-  --tw-backdrop-blur:  ;
-  --tw-backdrop-brightness:  ;
-  --tw-backdrop-contrast:  ;
-  --tw-backdrop-grayscale:  ;
-  --tw-backdrop-hue-rotate:  ;
-  --tw-backdrop-invert:  ;
-  --tw-backdrop-opacity:  ;
-  --tw-backdrop-saturate:  ;
-  --tw-backdrop-sepia:  ;
-  --tw-contain-size:  ;
-  --tw-contain-layout:  ;
-  --tw-contain-paint:  ;
-  --tw-contain-style:  ;
+  --tw-blur: ;
+  --tw-brightness: ;
+  --tw-contrast: ;
+  --tw-grayscale: ;
+  --tw-hue-rotate: ;
+  --tw-invert: ;
+  --tw-saturate: ;
+  --tw-sepia: ;
+  --tw-drop-shadow: ;
+  --tw-backdrop-blur: ;
+  --tw-backdrop-brightness: ;
+  --tw-backdrop-contrast: ;
+  --tw-backdrop-grayscale: ;
+  --tw-backdrop-hue-rotate: ;
+  --tw-backdrop-invert: ;
+  --tw-backdrop-opacity: ;
+  --tw-backdrop-saturate: ;
+  --tw-backdrop-sepia: ;
+  --tw-contain-size: ;
+  --tw-contain-layout: ;
+  --tw-contain-paint: ;
+  --tw-contain-style: ;
 }
 
 ::backdrop {
@@ -510,19 +513,19 @@ video {
   --tw-skew-y: 0;
   --tw-scale-x: 1;
   --tw-scale-y: 1;
-  --tw-pan-x:  ;
-  --tw-pan-y:  ;
-  --tw-pinch-zoom:  ;
+  --tw-pan-x: ;
+  --tw-pan-y: ;
+  --tw-pinch-zoom: ;
   --tw-scroll-snap-strictness: proximity;
-  --tw-gradient-from-position:  ;
-  --tw-gradient-via-position:  ;
-  --tw-gradient-to-position:  ;
-  --tw-ordinal:  ;
-  --tw-slashed-zero:  ;
-  --tw-numeric-figure:  ;
-  --tw-numeric-spacing:  ;
-  --tw-numeric-fraction:  ;
-  --tw-ring-inset:  ;
+  --tw-gradient-from-position: ;
+  --tw-gradient-via-position: ;
+  --tw-gradient-to-position: ;
+  --tw-ordinal: ;
+  --tw-slashed-zero: ;
+  --tw-numeric-figure: ;
+  --tw-numeric-spacing: ;
+  --tw-numeric-fraction: ;
+  --tw-ring-inset: ;
   --tw-ring-offset-width: 0px;
   --tw-ring-offset-color: #fff;
   --tw-ring-color: rgb(59 130 246 / 0.5);
@@ -530,28 +533,28 @@ video {
   --tw-ring-shadow: 0 0 #0000;
   --tw-shadow: 0 0 #0000;
   --tw-shadow-colored: 0 0 #0000;
-  --tw-blur:  ;
-  --tw-brightness:  ;
-  --tw-contrast:  ;
-  --tw-grayscale:  ;
-  --tw-hue-rotate:  ;
-  --tw-invert:  ;
-  --tw-saturate:  ;
-  --tw-sepia:  ;
-  --tw-drop-shadow:  ;
-  --tw-backdrop-blur:  ;
-  --tw-backdrop-brightness:  ;
-  --tw-backdrop-contrast:  ;
-  --tw-backdrop-grayscale:  ;
-  --tw-backdrop-hue-rotate:  ;
-  --tw-backdrop-invert:  ;
-  --tw-backdrop-opacity:  ;
-  --tw-backdrop-saturate:  ;
-  --tw-backdrop-sepia:  ;
-  --tw-contain-size:  ;
-  --tw-contain-layout:  ;
-  --tw-contain-paint:  ;
-  --tw-contain-style:  ;
+  --tw-blur: ;
+  --tw-brightness: ;
+  --tw-contrast: ;
+  --tw-grayscale: ;
+  --tw-hue-rotate: ;
+  --tw-invert: ;
+  --tw-saturate: ;
+  --tw-sepia: ;
+  --tw-drop-shadow: ;
+  --tw-backdrop-blur: ;
+  --tw-backdrop-brightness: ;
+  --tw-backdrop-contrast: ;
+  --tw-backdrop-grayscale: ;
+  --tw-backdrop-hue-rotate: ;
+  --tw-backdrop-invert: ;
+  --tw-backdrop-opacity: ;
+  --tw-backdrop-saturate: ;
+  --tw-backdrop-sepia: ;
+  --tw-contain-size: ;
+  --tw-contain-layout: ;
+  --tw-contain-paint: ;
+  --tw-contain-style: ;
 }
 
 .container {
@@ -798,7 +801,7 @@ video {
   gap: 0.5rem;
 }
 
-.space-y-4 > :not([hidden]) ~ :not([hidden]) {
+.space-y-4> :not([hidden])~ :not([hidden]) {
   --tw-space-y-reverse: 0;
   margin-top: calc(1rem * calc(1 - var(--tw-space-y-reverse)));
   margin-bottom: calc(1rem * var(--tw-space-y-reverse));
@@ -1223,6 +1226,18 @@ video {
 @media (min-width: 768px) {
   .md\:grid-cols-2 {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media only screen and (max-width: 560px) {
+  .hidesmall {
+    display: none;
+  }
+}
+
+@media only screen and (min-width: 560px) {
+  .showsmall {
+    display: none;
   }
 }
 

--- a/tool-scripts/XProtectVersionCheck-EA.sh
+++ b/tool-scripts/XProtectVersionCheck-EA.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/bin/zsh --no-rcs
 # shellcheck shell=bash
 
 ## based on Graham Pugh's version https://github.com/grahampugh/osx-scripts/blob/main/check-xprotect-version/XProtectVersionCheck-EA.sh

--- a/tool-scripts/macOSVersionCheck-EA.sh
+++ b/tool-scripts/macOSVersionCheck-EA.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/bin/zsh --no-rcs
 # shellcheck shell=bash
 
 # Check if the local system matches the latest available compatible version using SOFA


### PR DESCRIPTION
This is part 1 of trying to address the way the heading looks on an iPhone 13 mini...

<img width="415" alt="iPhone 13 mini" src="https://github.com/macadmins/sofa/assets/5802725/8684c56e-d845-41c7-b1fc-970b798996ef">

The idea is to remove the text from the top row once it gets too narrow (560px).

<img width="615" alt="reduced width" src="https://github.com/macadmins/sofa/assets/5802725/a285acba-3f6d-4597-a941-3c0e401333bf">

Unfortunately when I pressed save, it did a bunch of linting of the format, so it's harder to see the very minor changes!

So, TL;DR, I introduced `hidesmall` and `showsmall` classes, which hides the text from the top row at less than 560px and shows it underneath instead.

I'd also like to address the buttons which are falling off the left of the screen, but I haven't yet figured out how to make those buttons appear locally :-) 



