### PR TITLE
Prevent CVE-2024-27301 exploit of zsh scripts

### DIFF
--- a/tool-scripts/XProtectVersionCheck-EA.sh
+++ b/tool-scripts/XProtectVersionCheck-EA.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/bin/zsh --no-rcs
 # shellcheck shell=bash
 
 ## based on Graham Pugh's version https://github.com/grahampugh/osx-scripts/blob/main/check-xprotect-version/XProtectVersionCheck-EA.sh

--- a/tool-scripts/macOSVersionCheck-EA.sh
+++ b/tool-scripts/macOSVersionCheck-EA.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/bin/zsh --no-rcs
 # shellcheck shell=bash
 
 # Check if the local system matches the latest available compatible version using SOFA


### PR DESCRIPTION
Adding `--no-rcs` to the zsh shebang prevents these scripts being a part of the CVE-2024-27301 exploit which can execute lines in `.zshenv` as root.