### PR TITLE
Fix writing of timestamp file location, respect env variable

### DIFF
--- a/build-sofa-feed.py
+++ b/build-sofa-feed.py
@@ -527,7 +527,7 @@ def compute_hash(data):
     return hashlib.sha256(json_str).hexdigest()
 
 
-def write_timestamp_and_hash(os_type, hash_value, filename="timestamp.json"):
+def write_timestamp_and_hash(os_type, hash_value, filename=None):
     """
     Update the timestamp and hash value for a specific OS type in a JSON file. This function constructs
     a current timestamp and a hash over the full JSON data, and then updates or creates a JSON file 


### PR DESCRIPTION
When run via GitHub Action the `-e TIMESTAMP_FILE_PATH=/app/v1/timestamp.json` must be used 