### PR TITLE
RSS Feed

### DIFF
--- a/.github/workflows/run_docker_macos_workflow.yml
+++ b/.github/workflows/run_docker_macos_workflow.yml
@@ -43,6 +43,6 @@ jobs:
         timestamp=$(date +'%Y-%m-%d %H:%M:%S')
         git config --global user.name 'github-actions'
         git config --global user.email 'github-actions@github.com'
-        git add v1/*.json time-series.csv
+        git add v1/*.json v1/*.xml cache/*.json time-series.csv
         git commit -m "Update SOFA data - $timestamp" -a || exit 0
         git push

--- a/.github/workflows/run_docker_macos_workflow.yml
+++ b/.github/workflows/run_docker_macos_workflow.yml
@@ -30,6 +30,7 @@ jobs:
       run: |
         docker cp sofa_scan_container:/app/v1/timestamp.json v1/. || echo "Failed to copy timestamp.json"
         docker cp sofa_scan_container:/app/macos_data_feed.json v1/. || true
+        docker cp sofa_scan_container:/app/macos_rss_feed.xml v1/. || true
         docker cp sofa_scan_container:/app/ios_data_feed.json v1/. || true
         docker cp sofa_scan_container:/app/time-series.csv .
 

--- a/.github/workflows/run_docker_macos_workflow.yml
+++ b/.github/workflows/run_docker_macos_workflow.yml
@@ -32,6 +32,7 @@ jobs:
         docker cp sofa_scan_container:/app/macos_data_feed.json v1/. || true
         docker cp sofa_scan_container:/app/macos_rss_feed.xml v1/. || true
         docker cp sofa_scan_container:/app/ios_data_feed.json v1/. || true
+        docker cp sofa_scan_container:/app/ios_rss_feed.xml v1/. || true
         docker cp sofa_scan_container:/app/time-series.csv .
 
 

--- a/.github/workflows/run_docker_macos_workflow.yml
+++ b/.github/workflows/run_docker_macos_workflow.yml
@@ -30,9 +30,8 @@ jobs:
       run: |
         docker cp sofa_scan_container:/app/v1/timestamp.json v1/. || echo "Failed to copy timestamp.json"
         docker cp sofa_scan_container:/app/macos_data_feed.json v1/. || true
-        docker cp sofa_scan_container:/app/macos_rss_feed.xml v1/. || true
         docker cp sofa_scan_container:/app/ios_data_feed.json v1/. || true
-        docker cp sofa_scan_container:/app/ios_rss_feed.xml v1/. || true
+        docker cp sofa_scan_container:/app/rss_feed.xml v1/. || true
         docker cp sofa_scan_container:/app/time-series.csv .
 
 

--- a/.github/workflows/run_docker_macos_workflow.yml
+++ b/.github/workflows/run_docker_macos_workflow.yml
@@ -32,6 +32,7 @@ jobs:
         docker cp sofa_scan_container:/app/macos_data_feed.json v1/. || true
         docker cp sofa_scan_container:/app/ios_data_feed.json v1/. || true
         docker cp sofa_scan_container:/app/rss_feed.xml v1/. || true
+        docker cp sofa_scan_container:/app/cache . || echo "Failed to copy cache files"
         docker cp sofa_scan_container:/app/time-series.csv .
 
 

--- a/README.md
+++ b/README.md
@@ -49,11 +49,12 @@ SOFA supports a wide array of practical applications, wether for MacAdmin toolin
 
 ## RSS Overview
 
-The RSS feed is generated using `feedgen` by leveraging the same data generated for the data feed. It extracts `SecurityReleases` and injects them into individual entries, providing a streamlined and organized feed of the latest updates. The process involves:
+The RSS feed is generated using [feedgen](https://feedgen.kiesow.be/) by leveraging the same data generated for the data feed. It extracts `SecurityReleases` and injects them into individual entries, providing a streamlined and organized feed of the latest updates. The process involves:
 
 1. **Loading Cache Data**: RSS data is loaded from cached JSON files from the `cache/` directory to ensure all previously fetched updates are considered.
 1. **Writing to Cache**: New or updated data is written back to the cache, sorted by `ReleaseDate`.
 1. **Diffing Data**: New feed results are compared against existing cached data to identify and handle new entries.
+1. **Generate New Cache**: Updating the current cache files with new entries if new entries exist.
 1. **Creating RSS Entries**: `SecurityReleases` from the data feed are used to create RSS entries, including handling specific data like `XProtect` configurations and payloads.
 1. **Writing RSS Feed**: The sorted and updated entries are written to an RSS feed file (`v1/rss_feed.xml`) using `feedgen`.
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ Updated automatically via GitHub Actions, the SOFA feed is a dynamic, centralize
 
 ## Key Features
 
-### Machine-Readable Feed and Web UI
+### Machine-Readable Feed, RSS Feed, and Web UI
 
 - **JSON Feed**: Provides detailed, machine-readable data optimized for automated tools and scripts
+- **RSS Feed**: Provides RSS Feed for use with entries sorted by date released
 - **Web Interface**: Divided between the major version tabs at the top and organized into sections that cover the latest OS information, XProtect updates, and security details for each OS, SOFA facilitates both quick summaries and deep dives into relevant data points
 
 ### Use Cases

--- a/README.md
+++ b/README.md
@@ -47,6 +47,16 @@ SOFA supports a wide array of practical applications, wether for MacAdmin toolin
 - **Vulnerability Details:**  For each CVE, links are provided to view detailed records at CISA.gov or CVE.org. Use 'Command-click' to open a CVE record on the NVD website, highlighting detailed info on actively exploited vulnerabilities and related security advisories
 - **Search and Highlight**: Search for specific CVEs to identify which OS updates address the vulnerabilities
 
+## RSS Overview
+
+The RSS feed is generated using `feedgen` by leveraging the same data generated for the data feed. It extracts `SecurityReleases` and injects them into individual entries, providing a streamlined and organized feed of the latest updates. The process involves:
+
+1. **Loading Cache Data**: RSS data is loaded from cached JSON files from the `cache/` directory to ensure all previously fetched updates are considered.
+1. **Writing to Cache**: New or updated data is written back to the cache, sorted by `ReleaseDate`.
+1. **Diffing Data**: New feed results are compared against existing cached data to identify and handle new entries.
+1. **Creating RSS Entries**: `SecurityReleases` from the data feed are used to create RSS entries, including handling specific data like `XProtect` configurations and payloads.
+1. **Writing RSS Feed**: The sorted and updated entries are written to an RSS feed file (`v1/rss_feed.xml`) using `feedgen`.
+
 ## Getting Started
 
 ### Access the Web UI

--- a/build-sofa-feed.py
+++ b/build-sofa-feed.py
@@ -567,7 +567,7 @@ def diff_rss_data(os_type, feed_results):
 
         return combined_data
     except Exception as e:
-        print(f"Error diffing rss data with cache: {e}")
+        print(f"Error diffing RSS data with cache: {e}")
         return json_data + x_data
 
 
@@ -691,10 +691,8 @@ def write_data_to_rss(sorted_feed, filename):
             feed_entry = feed_gen.add_entry()
             feed_entry.id(f"{release['UpdateName'].split(' ')[0]}_{release['ProductVersion']}")
             feed_entry.title(release["UpdateName"])
-            feed_entry.link(link={"href":"https://sofa.macadmins.io/"})
+            feed_entry.link(link={"href": "https://sofa.macadmins.io/"})
 
-            # Format the CVEs for description to make it pretty like how
-            # the website looks like
             description = ""
 
             if "UniqueCVEsCount" in release:
@@ -702,17 +700,13 @@ def write_data_to_rss(sorted_feed, filename):
 
             if "CVEs" in release:
                 exploited = sum(value is True for value in release["CVEs"].values())
-
-                description += (
-                    f"Exploited CVE(s): {exploited}<br>"
-                )
+                description += f"Exploited CVE(s): {exploited}<br>"
 
             if "DaysSincePreviousRelease" in release:
                 description += f"Days to Prev. Release: {release['DaysSincePreviousRelease']}"
 
             feed_entry.description(description)
             publication_date = release["ReleaseDate"]
-
             feed_entry.published(publication_date)
 
         feed_gen.rss_file(filename, pretty=True)

--- a/build-sofa-feed.py
+++ b/build-sofa-feed.py
@@ -689,7 +689,7 @@ def write_data_to_rss(sorted_feed, filename):
         # For each item in the sorted list, create a new entry in RSS Feed
         for release in sorted_feed:
             feed_entry = feed_gen.add_entry()
-            feed_entry.id(release["ProductVersion"])
+            feed_entry.id(f"{release['UpdateName'].split(' ')[0]}_{release['ProductVersion']}")
             feed_entry.title(release["UpdateName"])
             feed_entry.link(link={"href":"https://sofa.macadmins.io/"})
 

--- a/build-sofa-feed.py
+++ b/build-sofa-feed.py
@@ -550,7 +550,8 @@ def write_data_to_rss(sorted_feed, filename):
         # Set the primary feed information
         feed_gen = FeedGenerator()
         feed_gen.id("https://sofa.macadmins.io")
-        feed_gen.title(f"SOFA - {filename.split('_')[0]} feed")
+        feed_gen.title(f"SOFA - {filename.split('_')[0]} Update Feed")
+        feed_gen.description("This feed includes updates on OS versions and security info.")
         feed_gen.author({"name": "Mac Admins"})
         feed_gen.link(href="https://sofa.macadmins.io", rel="alternate")
         feed_gen.logo("https://sofa.macadmins.io/images/custom_logo.png")
@@ -610,8 +611,7 @@ def write_data_to_rss(sorted_feed, filename):
 
             feed_entry.published(publication_date)
 
-        feed_gen.rss_str(pretty=True)
-        feed_gen.rss_file(filename)
+        feed_gen.rss_file(filename, pretty=True)
     except Exception as e:
         print(f"Error writing RSS feed: {e}")
 

--- a/index.html
+++ b/index.html
@@ -165,8 +165,8 @@
                 }
                 // Instead of a separate function, directly control the XProtect card visibility here
                 requestAnimationFrame(() => {
-                document.getElementById('xprotect-card').style.display = software.osType === 'iOS' ? 'none' : '';
-            });
+                    document.getElementById('xprotect-card').style.display = software.osType === 'iOS' ? 'none' : '';
+                });
             });
             tabsContainer.appendChild(button);
         });

--- a/index.html
+++ b/index.html
@@ -275,11 +275,13 @@
 
 
     function updateUIWithOSData(specificVersionData, osType, fullData, installationApps) {
-        // Update the "Last Checked" and "Machine Readable Feed" sections
+        // Update the "Last Checked", "Machine Readable Feed", and "RSS Feed" sections
         loadLastCheckedDate(osType); // Load and display the last checked date for the selected OS type
         // document.getElementById('last-checked').innerHTML = `Last checked: <span class="text-indigo-700 dark:text-indigo-300">${fullData.LastCheck}</span>`;
-        const fullPath = `v1/${osType}_data_feed.json`;
-        document.getElementById('machine-readable-feed').innerHTML = `Machine readable feed: <a href="${createSafeLink('v1/' + osType.toLowerCase() + '_data_feed.json')}" class="text-blue-600 hover:text-blue-400 dark:text-yellow-500 dark:hover:text-yellow-300">v1/${osType.toLowerCase()}_data_feed.json</a>`;
+        const data_fullPath = `v1/${osType.toLowerCase()}_data_feed.json`;
+        const rss_fullPath = `v1/${osType.toLowerCase()}_rss_feed.xml`
+        document.getElementById('machine-readable-feed').innerHTML = `Machine readable feed: <a href="${createSafeLink(data_fullPath)}" class="text-blue-600 hover:text-blue-400 dark:text-yellow-500 dark:hover:text-yellow-300">${data_fullPath}</a>`;
+        document.getElementById('rss-feed').innerHTML = `RSS feed: <a href="${createSafeLink(rss_fullPath)}" class="text-blue-600 hover:text-blue-400 dark:text-yellow-500 dark:hover:text-yellow-300">${rss_fullPath}</a>`;
 
         // Populate the version card with specific version data and installation apps
         populateVersionCard(specificVersionData, osType, installationApps);

--- a/index.html
+++ b/index.html
@@ -88,7 +88,8 @@
     </div>
     <!-- Adjust informational text colors for light mode -->
     <div id="last-checked" class="mb-2 text-indigo-700 dark:text-indigo-400"></div>
-    <div id="machine-readable-feed" class="text-indigo-700 dark:text-indigo-400 mb-6" title="Frequently updated with the latest security patches and updates."></div>
+    <div id="machine-readable-feed" class="text-indigo-700 dark:text-indigo-400" title="Frequently updated with the latest security patches and updates."></div>
+    <div id="rss-feed" class="text-indigo-700 dark:text-indigo-400 mb-6" title="Frequently updated with the latest security patches and updates."></div>
      <!-- New container for both the version card and XProtect card -->
 
      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">

--- a/index.html
+++ b/index.html
@@ -57,22 +57,28 @@
         </div>
         </div>
         <div class="flex items-center ml-1">
-          <!-- Theme Toggle Button -->
-          <button id="theme-toggle" data-tooltip-target="tooltip-toggle" type="button" class="inline-flex items-center justify-center hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg w-10 h-10 mr-2">
-            <svg id="theme-toggle-dark-icon" class="w-4 h-4 hidden" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 18 20">
-              <path d="M17.8 13.75a1 1 0 0 0-.859-.5A7.488 7.488 0 0 1 10.52 2a1 1 0 0 0 0-.969A1.035 1.035 0 0 0 9.687.5h-.113a9.5 9.5 0 1 0 8.222 14.247 1 1 0 0 0 .004-.997Z"></path>
-            </svg>
-            <svg id="theme-toggle-light-icon" class="w-4 h-4" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20">
-              <path d="M10 15a5 5 0 1 0 0-10 5 5 0 0 0 0 10Zm0-11a1 1 0 0 0 1-1V1a1 1 0 0 0-2 0v2a1 1 0 0 0 1 1Zm0 12a1 1 0 0 0-1 1v2a1 1 0 1 0 2 0v-2a1 1 0 0 0-1-1ZM4.343 5.757a1 1 0 0 0 1.414-1.414L4.343 2.929a1 1 0 0 0-1.414 1.414l1.414 1.414Zm11.314 8.486a1 1 0 0 0-1.414 1.414l1.414 1.414a1 1 0 0 0 1.414-1.414l-1.414-1.414ZM4 10a1 1 0 0 0-1-1H1a1 1 0 0 0 0 2h2a1 1 0 0 0 1-1Zm15-1h-2a1 1 0 1 0 0 2h2a1 1 0 0 0 0-2ZM4.343 14.243l-1.414 1.414a1 1 0 1 0 1.414 1.414l1.414-1.414a1 1 0 0 0-1.414-1.414ZM14.95 6.05a1 1 0 0 0 .707-.293l1.414-1.414a1 1 0 1 0-1.414-1.414l-1.414 1.414a1 1 0 0 0 .707 1.707Z"></path>
-            </svg>
-          </button>
-          <!-- Github Link -->
-          <a href="https://github.com/macadmins/sofa" target="_blank" aria-label="GitHub" class="inline-flex items-center justify-center hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg w-10 h-10">
-            <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 496 512" class="h-5 w-5">
-              <path d="M165.9 397.4c0 2-2.3 3.6-5.2 3.6-3.3 .3-5.6-1.3-5.6-3.6 0-2 2.3-3.6 5.2-3.6 3-.3 5.6 1.3 5.6 3.6zm-31.1-4.5c-.7 2 1.3 4.3 4.3 4.9 2.6 1 5.6 0 6.2-2s-1.3-4.3-4.3-5.2c-2.6-.7-5.5 .3-6.2 2.3zm44.2-1.7c-2.9 .7-4.9 2.6-4.6 4.9 .3 2 2.9 3.3 5.9 2.6 2.9-.7 4.9-2.6 4.6-4.6-.3-1.9-3-3.2-5.9-2.9zM244.8 8C106.1 8 0 113.3 0 252c0 110.9 69.8 205.8 169.5 239.2 12.8 2.3 17.3-5.6 17.3-12.1 0-6.2-.3-40.4-.3-61.4 0 0-70 15-84.7-29.8 0 0-11.4-29.1-27.8-36.6 0 0-22.9-15.7 1.6-15.4 0 0 24.9 2 38.6 25.8 21.9 38.6 58.6 27.5 72.9 20.9 2.3-16 8.8-27.1 16-33.7-55.9-6.2-112.3-14.3-112.3-110.5 0-27.5 7.6-41.3 23.6-58.9-2.6-6.5-11.1-33.3 2.6-67.9 20.9-6.5 69 27 69 27 20-5.6 41.5-8.5 62.8-8.5s42.8 2.9 62.8 8.5c0 0 48.1-33.6 69-27 13.7 34.7 5.2 61.4 2.6 67.9 16 17.7 25.8 31.5 25.8 58.9 0 96.5-58.9 104.2-114.8 110.5 9.2 7.9 17 22.9 17 46.4 0 33.7-.3 75.4-.3 83.6 0 6.5 4.6 14.4 17.3 12.1C428.2 457.8 496 362.9 496 252 496 113.3 383.5 8 244.8 8zM97.2 352.9c-1.3 1-1 3.3 .7 5.2 1.6 1.6 3.9 2.3 5.2 1 1.3-1 1-3.3-.7-5.2-1.6-1.6-3.9-2.3-5.2-1zm-10.8-8.1c-.7 1.3 .3 2.9 2.3 3.9 1.6 1 3.6 .7 4.3-.7 .7-1.3-.3-2.9-2.3-3.9-2-.6-3.6-.3-4.3 .7zm32.4 35.6c-1.6 1.3-1 4.3 1.3 6.2 2.3 2.3 5.2 2.6 6.5 1 1.3-1.3 .7-4.3-1.3-6.2-2.2-2.3-5.2-2.6-6.5-1zm-11.4-14.7c-1.6 1-1.6 3.6 0 5.9 1.6 2.3 4.3 3.3 5.6 2.3 1.6-1.3 1.6-3.9 0-6.2-1.4-2.3-4-3.3-5.6-2z" />
-          </svg>
-        </a>
-      </div>
+            <!-- Theme Toggle Button -->
+            <button id="theme-toggle" data-tooltip-target="tooltip-toggle" type="button" class="inline-flex items-center justify-center hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg w-10 h-10 mr-2">
+              <svg id="theme-toggle-dark-icon" class="w-4 h-4 hidden" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 18 20">
+                <path d="M17.8 13.75a1 1 0 0 0-.859-.5A7.488 7.488 0 0 1 10.52 2a1 1 0 0 0 0-.969A1.035 1.035 0 0 0 9.687.5h-.113a9.5 9.5 0 1 0 8.222 14.247 1 1 0 0 0 .004-.997Z"></path>
+              </svg>
+              <svg id="theme-toggle-light-icon" class="w-4 h-4" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20">
+                <path d="M10 15a5 5 0 1 0 0-10 5 5 0 0 0 0 10Zm0-11a1 1 0 0 0 1-1V1a1 1 0 0 0-2 0v2a1 1 0 0 0 1 1Zm0 12a1 1 0 0 0-1 1v2a1 1 0 1 0 2 0v-2a1 1 0 0 0-1-1ZM4.343 5.757a1 1 0 0 0 1.414-1.414L4.343 2.929a1 1 0 0 0-1.414 1.414l1.414 1.414Zm11.314 8.486a1 1 0 0 0-1.414 1.414l1.414 1.414a1 1 0 0 0 1.414-1.414l-1.414-1.414ZM4 10a1 1 0 0 0-1-1H1a1 1 0 0 0 0 2h2a1 1 0 0 0 1-1Zm15-1h-2a1 1 0 1 0 0 2h2a1 1 0 0 0 0-2ZM4.343 14.243l-1.414 1.414a1 1 0 1 0 1.414 1.414l1.414-1.414a1 1 0 0 0-1.414-1.414ZM14.95 6.05a1 1 0 0 0 .707-.293l1.414-1.414a1 1 0 1 0-1.414-1.414l-1.414 1.414a1 1 0 0 0 .707 1.707Z"></path>
+              </svg>
+            </button>
+            <!-- GitHub Link -->
+            <a href="https://github.com/macadmins/sofa" target="_blank" aria-label="GitHub" class="inline-flex items-center justify-center hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg w-10 h-10 mr-2">
+              <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 496 512" class="h-5 w-5">
+                <path d="M165.9 397.4c0 2-2.3 3.6-5.2 3.6-3.3 .3-5.6-1.3-5.6-3.6 0-2 2.3-3.6 5.2-3.6 3-.3 5.6 1.3 5.6 3.6zm-31.1-4.5c-.7 2 1.3 4.3 4.3 4.9 2.6 1 5.6 0 6.2-2s-1.3-4.3-4.3-5.2c-2.6-.7-5.5 .3-6.2 2.3zm44.2-1.7c-2.9 .7-4.9 2.6-4.6 4.9 .3 2 2.9 3.3 5.9 2.6 2.9-.7 4.9-2.6 4.6-4.6-.3-1.9-3-3.2-5.9-2.9zM244.8 8C106.1 8 0 113.3 0 252c0 110.9 69.8 205.8 169.5 239.2 12.8 2.3 17.3-5.6 17.3-12.1 0-6.2-.3-40.4-.3-61.4 0 0-70 15-84.7-29.8 0 0-11.4-29.1-27.8-36.6 0 0-22.9-15.7 1.6-15.4 0 0 24.9 2 38.6 25.8 21.9 38.6 58.6 27.5 72.9 20.9 2.3-16 8.8-27.1 16-33.7-55.9-6.2-112.3-14.3-112.3-110.5 0-27.5 7.6-41.3 23.6-58.9-2.6-6.5-11.1-33.3 2.6-67.9 20.9-6.5 69 27 69 27 20-5.6 41.5-8.5 62.8-8.5s42.8 2.9 62.8 8.5c0 0 48.1-33.6 69-27 13.7 34.7 5.2 61.4 2.6 67.9 16 17.7 25.8 31.5 25.8 58.9 0 96.5-58.9 104.2-114.8 110.5 9.2 7.9 17 22.9 17 46.4 0 33.7-.3 75.4-.3 83.6 0 6.5 4.6 14.4 17.3 12.1C428.2 457.8 496 362.9 496 252 496 113.3 383.5 8 244.8 8zM97.2 352.9c-1.3 1-1 3.3 .7 5.2 1.6 1.6 3.9 2.3 5.2 1 1.3-1 1-3.3-.7-5.2-1.6-1.6-3.9-2.3-5.2-1zm-10.8-8.1c-.7 1.3 .3 2.9 2.3 3.9 1.6 1 3.6 .7 4.3-.7 .7-1.3-.3-2.9-2.3-3.9-2-.6-3.6-.3-4.3 .7zm32.4 35.6c-1.6 1.3-1 4.3 1.3 6.2 2.3 2.3 5.2 2.6 6.5 1 1.3-1.3 .7-4.3-1.3-6.2-2.2-2.3-5.2-2.6-6.5-1zm-11.4-14.7c-1.6 1-1.6 3.6 0 5.9 1.6 2.3 4.3 3.3 5.6 2.3 1.6-1.3 1.6-3.9 0-6.2-1.4-2.3-4-3.3-5.6-2z" />
+              </svg>
+            </a>
+            <!-- RSS Feed Link -->
+            <a href="v1/rss_feed.xml" target="_blank" aria-label="RSS Feed" class="inline-flex items-center justify-center hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg w-10 h-10">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 24 24" class="h-5 w-5">
+                    <path d="M4.98 8.68c5.2 0 9.4 4.2 9.4 9.4v1.58a1 1 0 0 1-2 0v-1.58c0-4.08-3.32-7.4-7.4-7.4h-1.58a1 1 0 0 1 0-2h1.58Zm0-4.98c8 0 14.4 6.4 14.4 14.4v1.58a1 1 0 1 1-2 0v-1.58c0-6.92-5.48-12.4-12.4-12.4h-1.58a1 1 0 0 1 0-2h1.58Zm.82 17.7a1.7 1.7 0 1 0-3.4 0 1.7 1.7 0 0 0 3.4 0Z" />
+                </svg>
+            </a>
+          </div>
     </div>
     <div class="flex flex-col sm:flex-row justify-between items-center mb-6">
       <div id="tabs" class="mb-6 flex"></div>
@@ -88,8 +94,7 @@
     </div>
     <!-- Adjust informational text colors for light mode -->
     <div id="last-checked" class="mb-2 text-indigo-700 dark:text-indigo-400"></div>
-    <div id="machine-readable-feed" class="text-indigo-700 dark:text-indigo-400" title="Frequently updated with the latest security patches and updates."></div>
-    <div id="rss-feed" class="text-indigo-700 dark:text-indigo-400 mb-6" title="Frequently updated with the latest security patches and updates."></div>
+    <div id="machine-readable-feed" class="text-indigo-700 dark:text-indigo-400 mb-6" title="Frequently updated with the latest security patches and updates."></div>
      <!-- New container for both the version card and XProtect card -->
 
      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -275,13 +280,11 @@
 
 
     function updateUIWithOSData(specificVersionData, osType, fullData, installationApps) {
-        // Update the "Last Checked", "Machine Readable Feed", and "RSS Feed" sections
+        // Update the "Last Checked" and "Machine Readable Feed" sections
         loadLastCheckedDate(osType); // Load and display the last checked date for the selected OS type
         // document.getElementById('last-checked').innerHTML = `Last checked: <span class="text-indigo-700 dark:text-indigo-300">${fullData.LastCheck}</span>`;
         const data_fullPath = `v1/${osType.toLowerCase()}_data_feed.json`;
-        const rss_fullPath = `v1/${osType.toLowerCase()}_rss_feed.xml`
         document.getElementById('machine-readable-feed').innerHTML = `Machine readable feed: <a href="${createSafeLink(data_fullPath)}" class="text-blue-600 hover:text-blue-400 dark:text-yellow-500 dark:hover:text-yellow-300">${data_fullPath}</a>`;
-        document.getElementById('rss-feed').innerHTML = `RSS feed: <a href="${createSafeLink(rss_fullPath)}" class="text-blue-600 hover:text-blue-400 dark:text-yellow-500 dark:hover:text-yellow-300">${rss_fullPath}</a>`;
 
         // Populate the version card with specific version data and installation apps
         populateVersionCard(specificVersionData, osType, installationApps);

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ requests
 pyyaml
 beautifulsoup4
 lxml
+feedgen


### PR DESCRIPTION
Taking a first stab at getting an RSS feed generated while building the structured data feed. Let me know what you all think and if it's the right direction here.

Feedback is welcome!

# Description

This RSS feed will consist of all Security Releases from each version of the OS. `build-sofa-feed.py` will take the `feed_structure` data and sort it out by creating a new list that just consists of `SecurityReleases` and sorts them by `ReleaseDate` while splitting away the `XProtect` data from `macOS` feed into it's own.

It will then cache the json data generated into a `cache` directory for use later to differentiate from new entries that are pulled from `feed_structure`.

It then uses [feedgen](https://pypi.org/project/feedgen/) module to create the XML that will be used as the RSS feed within the `write_data_to_rss` function. RSS feed entries usually get sorted by publish dates per OS, so in this case - we use the `ReleaseDate` as the publish date.

# Changes

## build-sofa-feed.py

- Added `ProductName` and `ReleaseType` to Data Feed. This allowed me to drive the structure of the RSS feed a bit easier and less code.
- For `ReleaseType`, the default is `OS` but when it comes to `Rapid Security Response` items, it's set to `RSR_{letter}`. For example, either `RSR_a` or `RSR_c`. It does a regex on the `UpdateName` to grab it.

### load_rss_data_cache

- Loads RSS data from cache files and returns combined data.

### write_os_data_to_cache

- Writes updated OS data to the cache.
- Sorts data by ReleaseDate before writing.
- Ensures the cache directory exists and handles exceptions during file writing.

### sort_data

- Sorts data by a specified key.
- Ensures data is sorted in ascending order by default.

### diff_rss_data

- Function used to check for new entries based on `ProductVersion`
- Diffs feed results and updates cache files for each OS type.
- Identifies and writes new entries to the cache.
- Merges cache and new data entries, removes duplicates, and sorts the combined data.

### remove_dict_duplicates

- Removes duplicate dictionaries from a list.
- Uses JSON serialization to handle unhashable types.

### create_rss_json_data

- Generates feed list from the given feed structure.
- Handles XProtect data separately and mimics other entries.

### write_data_to_rss

- Writes the sorted feed data to an RSS feed file.
- Sets up primary feed information and creates individual entries.

## index.html

- Added RSS Feed icon next to the GitHub icon, linked to the single feed file created here.
- Some indentation fixes.
- Variable cleanup for data feed links.

## README.md

Updated to account for RSS Feed

## docker workflows

- Accounting for new files generated and copied over

## requirements.txt

- Adding the feedgen module

# Tests

We ran the following lines to create the new xml files along with json files. Copied them into the `v1` directory for the webserver to pick up in testing. The code also created the cache structure within `cache/` for future use.
```bash
python3 ./build-sofa-feed.py iOS
python3 ./build-sofa-feed.py macOS
python3 ./build-sofa-feed.py macOS iOS
```

Established a webserver to view changes.
```
(.venv) ➜  sofa git:(rss_feed) ✗ python3 -m http.server 80           
Serving HTTP on :: port 80 (http://[::]:80/) ...
::1 - - [12/Jun/2024 11:26:45] "GET / HTTP/1.1" 200 -
::1 - - [12/Jun/2024 11:26:45] "GET /main.css HTTP/1.1" 304 -
::1 - - [12/Jun/2024 11:26:45] "GET /images/custom_logo.png HTTP/1.1" 200 -
::1 - - [12/Jun/2024 11:26:45] "GET /config.json HTTP/1.1" 304 -
::1 - - [12/Jun/2024 11:26:45] "GET /v1/macos_data_feed.json HTTP/1.1" 200 -
::1 - - [12/Jun/2024 11:26:45] "GET /v1/timestamp.json HTTP/1.1" 304 -
::1 - - [12/Jun/2024 11:26:45] "GET /essential_links.json HTTP/1.1" 304 -
::1 - - [12/Jun/2024 11:26:45] "GET /images/Sonoma.png HTTP/1.1" 200 -
::1 - - [12/Jun/2024 11:26:45] "GET /images/SWUpdate.png HTTP/1.1" 200 -
::1 - - [12/Jun/2024 11:26:53] "GET /v1/rss_feed.xml HTTP/1.1" 200 -
```

Docker build of image/
```
➜  sofa git:(rss_feed) ✗ docker build -t sofa_jramos .
[+] Building 16.0s (21/21) FINISHED                                                                                                   docker:desktop-linux
 => [internal] load build definition from dockerfile                                                                                                  0.0s
 => => transferring dockerfile: 1.12kB                                                                                                                0.0s
 => [internal] load metadata for docker.io/library/python:3.12-alpine                                                                                 2.1s
 => [internal] load .dockerignore                                                                                                                     0.0s
 => => transferring context: 2B                                                                                                                       0.0s
 => [internal] load build context                                                                                                                     0.0s
 => => transferring context: 73.55kB                                                                                                                  0.0s
 => [ 1/16] FROM docker.io/library/python:3.12-alpine@sha256:d24ed567ee3b972478a232ceff84b0d002e18ee9f5d38234ecbffece23dfa084                         3.5s
 => => resolve docker.io/library/python:3.12-alpine@sha256:d24ed567ee3b972478a232ceff84b0d002e18ee9f5d38234ecbffece23dfa084                           0.0s
 => => sha256:820650aa2f5b8e795b04058fa617fb87ad3397f0fc2582400f9855b84f2d4401 465.47kB / 465.47kB                                                    0.8s
 => => sha256:4e0f3549117ae48d35d3cbea60bca5ef0d654723e8065274c93137c3f2b44a60 14.68MB / 14.68MB                                                      2.7s
 => => sha256:d24ed567ee3b972478a232ceff84b0d002e18ee9f5d38234ecbffece23dfa084 1.65kB / 1.65kB                                                        0.0s
 => => sha256:6714e211c290dc39908616ed0befdcc8f9097b69ee62d17f2f1833d764b93ef0 1.37kB / 1.37kB                                                        0.0s
 => => sha256:0fe205a492b75b71368b95db211dc148d50240d50752f04b34d1024084561296 6.64kB / 6.64kB                                                        0.0s
 => => sha256:94747bd812346354fd5042870b6e44e5406880a4e6b5736a9cf9c753110df11b 4.09MB / 4.09MB                                                        0.8s
 => => extracting sha256:94747bd812346354fd5042870b6e44e5406880a4e6b5736a9cf9c753110df11b                                                             0.1s
 => => extracting sha256:820650aa2f5b8e795b04058fa617fb87ad3397f0fc2582400f9855b84f2d4401                                                             0.1s
 => => sha256:a5b6895e2863b5497adb5d68fe8e5241835c9624c9a31fd2b8532b08da56b638 242B / 242B                                                            1.0s
 => => sha256:629a421706977cd903f62bb22483a0fa6cba236a94d23543e616bf5c24516467 2.74MB / 2.74MB                                                        3.3s
 => => extracting sha256:4e0f3549117ae48d35d3cbea60bca5ef0d654723e8065274c93137c3f2b44a60                                                             0.3s
 => => extracting sha256:a5b6895e2863b5497adb5d68fe8e5241835c9624c9a31fd2b8532b08da56b638                                                             0.0s
 => => extracting sha256:629a421706977cd903f62bb22483a0fa6cba236a94d23543e616bf5c24516467                                                             0.2s
 => [ 2/16] WORKDIR /app                                                                                                                              0.1s
 => [ 3/16] COPY build-sofa-feed.py /app/                                                                                                             0.0s
 => [ 4/16] COPY process_uma.py /app/                                                                                                                 0.0s
 => [ 5/16] COPY process_ipsw.py /app/                                                                                                                0.0s
 => [ 6/16] COPY config.json /app/                                                                                                                    0.0s
 => [ 7/16] COPY feed_structure_template_v1.yaml /app/                                                                                                0.0s
 => [ 8/16] COPY forked_builds.json /app/                                                                                                             0.0s
 => [ 9/16] COPY sofa-time-series.py /app/                                                                                                            0.0s
 => [10/16] COPY requirements.txt /app/                                                                                                               0.0s
 => [11/16] RUN touch time-series.csv || true                                                                                                         0.1s
 => [12/16] COPY time-series.csv /app/                                                                                                                0.0s
 => [13/16] COPY model_identifier_*.json /app/                                                                                                        0.0s
 => [14/16] RUN pip install --no-cache-dir -r requirements.txt                                                                                        9.9s
 => [15/16] COPY entrypoint.sh /app/                                                                                                                  0.0s
 => [16/16] RUN chmod +x /app/entrypoint.sh                                                                                                           0.1s
 => exporting to image                                                                                                                                0.1s
 => => exporting layers                                                                                                                               0.1s
 => => writing image sha256:ca4f664f32ada21ebfe13b6bf1a53eba8a87f4ad0eaa4b6ec94df6db62459944                                                          0.0s
 => => naming to docker.io/library/sofa_jramos
```

# Visuals

<img width="159" alt="Screenshot 2024-06-08 at 12 03 40 AM" src="https://github.com/macadmins/sofa/assets/1831340/c7c1601f-1882-48fd-99e0-7370874c8083">

![Screenshot 2024-06-12 at 11 46 03 AM](https://github.com/macadmins/sofa/assets/1831340/39fe2ac0-ceda-455b-9a45-cbbdfd1bbfe7)
![Screenshot 2024-06-12 at 11 45 50 AM](https://github.com/macadmins/sofa/assets/1831340/17fa3558-fa31-48f6-8c75-664e93ac04d7)
![Screenshot 2024-06-12 at 11 51 20 AM](https://github.com/macadmins/sofa/assets/1831340/830883cc-ebaa-4ea3-9b1c-018b002ecf89)
![Screenshot 2024-06-12 at 11 51 55 AM](https://github.com/macadmins/sofa/assets/1831340/b0f3927f-619c-44de-89ea-3ea5b3e87ab3)

