### PR TITLE
add CVE info to latest release

### DIFF
--- a/build-sofa-feed.py
+++ b/build-sofa-feed.py
@@ -758,6 +758,15 @@ def main(os_type):
                 )
 
             if os_type == "macOS":
+                latest_security_info = fetch_security_releases(
+                    os_type, latest_version_info["ProductVersion"]
+                )
+                if latest_security_info:
+                    latest_version_info["SecurityInfo"] = latest_security_info[0]["SecurityInfo"]
+                    latest_version_info["CVEs"] = latest_security_info[0]["CVEs"]
+                    latest_version_info["ActivelyExploitedCVEs"] = latest_security_info[0]["ActivelyExploitedCVEs"]
+                    latest_version_info["UniqueCVEsCount"] = latest_security_info[0]["UniqueCVEsCount"]
+
                 # Fetch compatible machines for the macOS version
                 compatible_machines = add_compatible_machines(os_version_name)
 


### PR DESCRIPTION
This extends the `Latest` to contain all of the relevant data from the Security Releases section

Ex:

```json
            "Latest": {
                "ProductVersion": "14.5",
                "Build": "23F79",
                "ReleaseDate": "2024-05-13T00:00:00Z",
                "ExpirationDate": "2024-08-15T00:00:00Z",
                "SupportedDevices": [
                    "J132AP",
                    "J137AP",
                    "J140AAP",
                    "J140KAP",
                    "J152FAP",
                    "J160AP",
                    "J174AP",
                    "J180dAP",
                    "J185AP",
                    "J185FAP",
                    "J213AP",
                    "J214KAP",
                    "J215AP",
                    "J223AP",
                    "J230KAP",
                    "J274AP",
                    "J293AP",
                    "J313AP",
                    "J314cAP",
                    "J314sAP",
                    "J316cAP",
                    "J316sAP",
                    "J375cAP",
                    "J375dAP",
                    "J413AP",
                    "J414cAP",
                    "J414sAP",
                    "J415AP",
                    "J416cAP",
                    "J416sAP",
                    "J433AP",
                    "J434AP",
                    "J456AP",
                    "J457AP",
                    "J473AP",
                    "J474sAP",
                    "J475cAP",
                    "J475dAP",
                    "J493AP",
                    "J504AP",
                    "J514cAP",
                    "J514mAP",
                    "J514sAP",
                    "J516cAP",
                    "J516mAP",
                    "J516sAP",
                    "J613AP",
                    "J615AP",
                    "J680AP",
                    "J780AP",
                    "Mac-1E7E29AD0135F9BC",
                    "Mac-63001698E7A34814",
                    "Mac-937A206F2EE63C01",
                    "Mac-AA95B1DDAB278B95",
                    "VMA2MACOSAP",
                    "VMM-x86_64"
                ],
                "CVEs": {
                    "CVE-2024-27804": false,
                    "CVE-2024-27837": false,
                    "CVE-2024-27816": false,
                    "CVE-2024-27825": false,
                    "CVE-2024-27829": false,
                    "CVE-2024-27841": false,
                    "CVE-2024-23236": false,
                    "CVE-2024-27827": false,
                    "CVE-2024-27818": false,
                    "CVE-2023-42893": false,
                    "CVE-2024-27810": false,
                    "CVE-2024-27822": false,
                    "CVE-2024-27824": false,
                    "CVE-2024-27813": false,
                    "CVE-2024-27843": false,
                    "CVE-2024-27821": false,
                    "CVE-2024-27798": false,
                    "CVE-2024-27847": false,
                    "CVE-2024-27842": false,
                    "CVE-2024-27796": false,
                    "CVE-2024-27834": false
                },
                "SecurityInfo": "https://support.apple.com/kb/HT214106",
                "ActivelyExploitedCVEs": [],
                "UniqueCVEsCount": 21
            },
```

This enables admins who build tooling around this to for instance have different logic to consume `latest` vs the `SecurityReleases` key but have similar access to the key pairs.