### PR TITLE
use local cached file and do etag checks to prevent unnecessary downloads

### DIFF
--- a/tool-scripts/XProtectVersionCheck-EA.sh
+++ b/tool-scripts/XProtectVersionCheck-EA.sh
@@ -13,8 +13,31 @@ autoload is-at-least
 
 # URL to the online JSON data
 online_json_url="https://sofa.macadmins.io/v1/macos_data_feed.json"
-json_data=$(/usr/bin/curl -L -m 3 -s "$online_json_url")
-if [[ ! "$json_data" ]]; then
+
+# local store
+json_cache_dir="/private/tmp/sofa"
+json_cache="$json_cache_dir/macos_data_feed.json"
+etag_cache="$json_cache_dir/macos_data_feed_etag.txt"
+
+# ensure local cache folder exists
+/bin/mkdir -p "$json_cache_dir"
+
+# check local vs online using etag
+if [[ -f "$etag_cache" && -f "$json_cache" ]]; then
+    if /usr/bin/curl --etag-compare "$etag_cache" "$online_json_url"; then
+        echo "Cached e-tag matches online e-tag - local cached file is up to date"
+    else
+        echo "Cached e-tag does not match online e-tag, proceeding to download"
+        /usr/bin/curl -L -m 3 -s "$online_json_url" --etag-save "$etag_cache" -o "$json_cache"
+    fi
+else
+    echo "No e-tag cached, proceeding to download"
+    /usr/bin/curl -L -m 3 -s "$online_json_url" --etag-save "$etag_cache" -o "$json_cache"
+fi
+
+echo
+
+if [[ ! "$json_cache" ]]; then
     echo "<result>Could not obtain data</result>"
     exit
 fi
@@ -37,7 +60,7 @@ fi
 echo
 
 # Extract the online version of XProtect configuration data
-onlineXProtectVersion=$(/usr/bin/plutil -extract "XProtectPlistConfigData.com\\.apple\\.XProtect" raw - - <<< "$json_data" | /usr/bin/head -n 1)
+onlineXProtectVersion=$(/usr/bin/plutil -extract "XProtectPlistConfigData.com\\.apple\\.XProtect" raw "$json_cache" | /usr/bin/head -n 1)
 echo "Online XProtect Version: $onlineXProtectVersion"
 
 # Extract the local installed version of XProtect configuration data
@@ -45,7 +68,7 @@ localXProtectVersion=$(/usr/bin/plutil -extract CFBundleShortVersionString raw /
 echo "Local XProtect Version: $localXProtectVersion"
 
 # Extract the online version of XProtect.app
-onlineXProtectAppVersion=$(/usr/bin/plutil -extract "XProtectPayloads.com\\.apple\\.XProtectFramework\\.XProtect" raw - - <<< "$json_data" | /usr/bin/head -n 1)
+onlineXProtectAppVersion=$(/usr/bin/plutil -extract "XProtectPayloads.com\\.apple\\.XProtectFramework\\.XProtect" raw "$json_cache" | /usr/bin/head -n 1)
 echo "Online XProtect.app Version: $onlineXProtectAppVersion"
 
 # Extract the local installed version of XProtect.app

--- a/tool-scripts/XProtectVersionCheck-EA.sh
+++ b/tool-scripts/XProtectVersionCheck-EA.sh
@@ -24,20 +24,23 @@ etag_cache="$json_cache_dir/macos_data_feed_etag.txt"
 
 # check local vs online using etag
 if [[ -f "$etag_cache" && -f "$json_cache" ]]; then
-    if /usr/bin/curl --etag-compare "$etag_cache" "$online_json_url"; then
-        echo "Cached e-tag matches online e-tag - local cached file is up to date"
+    if /usr/bin/curl --silent --etag-compare "$etag_cache" "$online_json_url" --output /dev/null; then
+        echo "Cached e-tag matches online e-tag - cached json file is up to date"
     else
-        echo "Cached e-tag does not match online e-tag, proceeding to download"
-        /usr/bin/curl -L -m 3 -s "$online_json_url" --etag-save "$etag_cache" -o "$json_cache"
+        echo "Cached e-tag does not match online e-tag, proceeding to download SOFA json file"
+        /usr/bin/curl --location --max-time 3 --silent "$online_json_url" --etag-save "$etag_cache" --output "$json_cache"
     fi
 else
-    echo "No e-tag cached, proceeding to download"
-    /usr/bin/curl -L -m 3 -s "$online_json_url" --etag-save "$etag_cache" -o "$json_cache"
+    echo "No e-tag cached, proceeding to download SOFA json file"
+    /usr/bin/curl --location --max-time 3 --silent "$online_json_url" --etag-save "$etag_cache" --output "$json_cache"
 fi
 
 echo
 
-if [[ ! "$json_cache" ]]; then
+if [[ ! -f "$json_cache" ]]; then
+    echo "<result>Could not obtain data</result>"
+    exit
+elif ! plutil -extract "UpdateHash" raw "$json_cache" > /dev/null; then
     echo "<result>Could not obtain data</result>"
     exit
 fi

--- a/tool-scripts/macOSCompatibilityCheck-EA.sh
+++ b/tool-scripts/macOSCompatibilityCheck-EA.sh
@@ -29,20 +29,23 @@ etag_cache="$json_cache_dir/macos_data_feed_etag.txt"
 
 # check local vs online using etag
 if [[ -f "$etag_cache" && -f "$json_cache" ]]; then
-    if /usr/bin/curl --etag-compare "$etag_cache" "$online_json_url"; then
-        echo "Cached e-tag matches online e-tag - local cached file is up to date"
+    if /usr/bin/curl --silent --etag-compare "$etag_cache" "$online_json_url" --output /dev/null; then
+        echo "Cached e-tag matches online e-tag - cached json file is up to date"
     else
-        echo "Cached e-tag does not match online e-tag, proceeding to download"
-        /usr/bin/curl -L -m 3 -s "$online_json_url" --etag-save "$etag_cache" -o "$json_cache"
+        echo "Cached e-tag does not match online e-tag, proceeding to download SOFA json file"
+        /usr/bin/curl --location --max-time 3 --silent "$online_json_url" --etag-save "$etag_cache" --output "$json_cache"
     fi
 else
-    echo "No e-tag cached, proceeding to download"
-    /usr/bin/curl -L -m 3 -s "$online_json_url" --etag-save "$etag_cache" -o "$json_cache"
+    echo "No e-tag cached, proceeding to download SOFA json file"
+    /usr/bin/curl --location --max-time 3 --silent "$online_json_url" --etag-save "$etag_cache" --output "$json_cache"
 fi
 
 echo
 
-if [[ ! "$json_cache" ]]; then
+if [[ ! -f "$json_cache" ]]; then
+    echo "<result>Could not obtain data</result>"
+    exit
+elif ! plutil -extract "UpdateHash" raw "$json_cache" > /dev/null; then
     echo "<result>Could not obtain data</result>"
     exit
 fi

--- a/tool-scripts/macOSCompatibilityCheck-EA.sh
+++ b/tool-scripts/macOSCompatibilityCheck-EA.sh
@@ -18,8 +18,31 @@ fi
 
 # URL to the online JSON data
 online_json_url="https://sofa.macadmins.io/v1/macos_data_feed.json"
-json_data=$(/usr/bin/curl -L -m 3 -s "$online_json_url")
-if [[ ! "$json_data" ]]; then
+
+# local store
+json_cache_dir="/private/tmp/sofa"
+json_cache="$json_cache_dir/macos_data_feed.json"
+etag_cache="$json_cache_dir/macos_data_feed_etag.txt"
+
+# ensure local cache folder exists
+/bin/mkdir -p "$json_cache_dir"
+
+# check local vs online using etag
+if [[ -f "$etag_cache" && -f "$json_cache" ]]; then
+    if /usr/bin/curl --etag-compare "$etag_cache" "$online_json_url"; then
+        echo "Cached e-tag matches online e-tag - local cached file is up to date"
+    else
+        echo "Cached e-tag does not match online e-tag, proceeding to download"
+        /usr/bin/curl -L -m 3 -s "$online_json_url" --etag-save "$etag_cache" -o "$json_cache"
+    fi
+else
+    echo "No e-tag cached, proceeding to download"
+    /usr/bin/curl -L -m 3 -s "$online_json_url" --etag-save "$etag_cache" -o "$json_cache"
+fi
+
+echo
+
+if [[ ! "$json_cache" ]]; then
     echo "<result>Could not obtain data</result>"
     exit
 fi
@@ -29,11 +52,11 @@ model=$(/usr/sbin/sysctl -n hw.model)
 echo "Model Identifier: $model"
 
 # 2. identify the latest major OS
-latest_os=$(/usr/bin/plutil -extract "OSVersions.0.OSVersion" raw -expect string - - <<< "$json_data" | /usr/bin/head -n 1)
+latest_os=$(/usr/bin/plutil -extract "OSVersions.0.OSVersion" raw -expect string "$json_cache" | /usr/bin/head -n 1)
 echo "Latest macOS: $latest_os"
 
 # 3. idenfity latest compatible major OS
-latest_compatible_os=$(/usr/bin/plutil -extract "Models.$model.SupportedOS.0" raw -expect string - - <<< "$json_data" | /usr/bin/head -n 1)
+latest_compatible_os=$(/usr/bin/plutil -extract "Models.$model.SupportedOS.0" raw -expect string "$json_cache" | /usr/bin/head -n 1)
 echo "Latest Compatible macOS: $latest_compatible_os"
 
 # 5. Compare latest with compatible


### PR DESCRIPTION
As discussed in Slack channel - this PR causes the EAs to cache the file locally along with an eTag file, which is used to compare local to online, so the full file is only downloaded when a change is made.

I chose `/private/tmp/sofa` as the cache folder, but this could be altered to something more permanent.