### PR TITLE
Adding acronym explanation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# SOFA
+# SOFA 
+**S**imple **O**rganized **F**eed for **A**pple Software Updates
 
 ![Sofa logo](./images/custom_logo.png "Optional title")
 


### PR DESCRIPTION
I mentioned SOFA in an AppleSeed event today and someone asked me what it stood for when I had the repo up, and I realized it wasn’t actually spelled out here.