### PR TITLE
reduce cron interval

### DIFF
--- a/.github/workflows/run_docker_macos_workflow.yml
+++ b/.github/workflows/run_docker_macos_workflow.yml
@@ -6,7 +6,7 @@ on:
     - cron: '0 17-20 * * 1,2,3,4,5'
     
     # On every day every 4 hours
-    - cron: '30 */4 * * *'
+    # - cron: '30 */4 * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Lately we have been seeing 403 client errors in the GDFM feed, this does affect the build of our feed files. 
Temporary reduction of cron activity for better analysis.