### PR TITLE
Add user agents to the Jamf EA scripts

### DIFF
--- a/tool-scripts/XProtectVersionCheck-EA.sh
+++ b/tool-scripts/XProtectVersionCheck-EA.sh
@@ -13,6 +13,7 @@ autoload is-at-least
 
 # URL to the online JSON data
 online_json_url="https://sofa.macadmins.io/v1/macos_data_feed.json"
+user_agent="SOFA-Jamf-EA-XProtectVersionCheck/1.0"
 
 # local store
 json_cache_dir="/private/tmp/sofa"
@@ -24,15 +25,15 @@ etag_cache="$json_cache_dir/macos_data_feed_etag.txt"
 
 # check local vs online using etag
 if [[ -f "$etag_cache" && -f "$json_cache" ]]; then
-    if /usr/bin/curl --silent --etag-compare "$etag_cache" "$online_json_url" --output /dev/null; then
+    if /usr/bin/curl --silent --etag-compare "$etag_cache" --header "User-Agent: $user_agent" "$online_json_url" --output /dev/null; then
         echo "Cached e-tag matches online e-tag - cached json file is up to date"
     else
         echo "Cached e-tag does not match online e-tag, proceeding to download SOFA json file"
-        /usr/bin/curl --location --max-time 3 --silent "$online_json_url" --etag-save "$etag_cache" --output "$json_cache"
+        /usr/bin/curl --location --max-time 3 --silent --header "User-Agent: $user_agent" "$online_json_url" --etag-save "$etag_cache" --output "$json_cache"
     fi
 else
     echo "No e-tag cached, proceeding to download SOFA json file"
-    /usr/bin/curl --location --max-time 3 --silent "$online_json_url" --etag-save "$etag_cache" --output "$json_cache"
+    /usr/bin/curl --location --max-time 3 --silent --header "User-Agent: $user_agent" "$online_json_url" --etag-save "$etag_cache" --output "$json_cache"
 fi
 
 echo

--- a/tool-scripts/XProtectVersionCheck-swiftDialog.sh
+++ b/tool-scripts/XProtectVersionCheck-swiftDialog.sh
@@ -9,6 +9,7 @@ swiftDialog_command="/usr/local/bin/dialog" # Path to swiftDialog installation
 
 # URL to the online JSON data
 online_json_url="https://sofa.macadmins.io/v1/macos_data_feed.json"
+user_agent="SOFA-dialog-XProtectVersionCheck/1.0"
 
 # local store
 json_cache_dir="/private/tmp/sofa"
@@ -20,15 +21,15 @@ etag_cache="$json_cache_dir/macos_data_feed_etag.txt"
 
 # check local vs online using etag
 if [[ -f "$etag_cache" && -f "$json_cache" ]]; then
-    if /usr/bin/curl --silent --etag-compare "$etag_cache" "$online_json_url" --output /dev/null; then
+    if /usr/bin/curl --silent --etag-compare "$etag_cache" --header "User-Agent: $user_agent" "$online_json_url" --output /dev/null; then
         echo "Cached e-tag matches online e-tag - cached json file is up to date"
     else
         echo "Cached e-tag does not match online e-tag, proceeding to download SOFA json file"
-        /usr/bin/curl --location --max-time 3 --silent "$online_json_url" --etag-save "$etag_cache" --output "$json_cache"
+        /usr/bin/curl --location --max-time 3 --silent --header "User-Agent: $user_agent" "$online_json_url" --etag-save "$etag_cache" --output "$json_cache"
     fi
 else
     echo "No e-tag cached, proceeding to download SOFA json file"
-    /usr/bin/curl --location --max-time 3 --silent "$online_json_url" --etag-save "$etag_cache" --output "$json_cache"
+    /usr/bin/curl --location --max-time 3 --silent --header "User-Agent: $user_agent" "$online_json_url" --etag-save "$etag_cache" --output "$json_cache"
 fi
 
 echo

--- a/tool-scripts/macOSCVECheck-EA.sh
+++ b/tool-scripts/macOSCVECheck-EA.sh
@@ -21,6 +21,7 @@ autoload is-at-least
 
 # URL to the online JSON data
 online_json_url="https://sofa.macadmins.io/v1/macos_data_feed.json"
+user_agent="SOFA-Jamf-EA-macOSCVECheck/1.0"
 
 # local store
 json_cache_dir="/private/tmp/sofa"
@@ -32,15 +33,15 @@ etag_cache="$json_cache_dir/macos_data_feed_etag.txt"
 
 # check local vs online using etag
 if [[ -f "$etag_cache" && -f "$json_cache" ]]; then
-    if /usr/bin/curl --silent --etag-compare "$etag_cache" "$online_json_url" --output /dev/null; then
+    if /usr/bin/curl --silent --etag-compare "$etag_cache" --header "User-Agent: $user_agent" "$online_json_url" --output /dev/null; then
         echo "Cached e-tag matches online e-tag - cached json file is up to date"
     else
         echo "Cached e-tag does not match online e-tag, proceeding to download SOFA json file"
-        /usr/bin/curl --location --max-time 3 --silent "$online_json_url" --etag-save "$etag_cache" --output "$json_cache"
+        /usr/bin/curl --location --max-time 3 --silent --header "User-Agent: $user_agent" "$online_json_url" --etag-save "$etag_cache" --output "$json_cache"
     fi
 else
     echo "No e-tag cached, proceeding to download SOFA json file"
-    /usr/bin/curl --location --max-time 3 --silent "$online_json_url" --etag-save "$etag_cache" --output "$json_cache"
+    /usr/bin/curl --location --max-time 3 --silent --header "User-Agent: $user_agent" "$online_json_url" --etag-save "$etag_cache" --output "$json_cache"
 fi
 
 echo

--- a/tool-scripts/macOSCompatibilityCheck-EA.sh
+++ b/tool-scripts/macOSCompatibilityCheck-EA.sh
@@ -26,6 +26,7 @@ fi
 
 # URL to the online JSON data
 online_json_url="https://sofa.macadmins.io/v1/macos_data_feed.json"
+user_agent="SOFA-Jamf-EA-macOSCompatibilityCheck/1.0"
 
 # local store
 json_cache_dir="/private/tmp/sofa"
@@ -37,18 +38,18 @@ etag_cache="$json_cache_dir/macos_data_feed_etag.txt"
 
 # check local vs online using etag (only available on macOS 12+)
 if [[ -f "$etag_cache" && -f "$json_cache" ]]; then
-    if /usr/bin/curl --silent --etag-compare "$etag_cache" "$online_json_url" --output /dev/null; then
+    if /usr/bin/curl --silent --etag-compare "$etag_cache" --header "User-Agent: $user_agent" "$online_json_url" --output /dev/null; then
         echo "Cached e-tag matches online e-tag - cached json file is up to date"
     else
         echo "Cached e-tag does not match online e-tag, proceeding to download SOFA json file"
-        /usr/bin/curl --location --max-time 3 --silent "$online_json_url" --etag-save "$etag_cache" --output "$json_cache"
+        /usr/bin/curl --location --max-time 3 --silent --header "User-Agent: $user_agent" "$online_json_url" --etag-save "$etag_cache" --output "$json_cache"
     fi
 elif [[ "$os_compatibility" == "legacy" ]]; then
     echo "No e-tag cached, proceeding to download SOFA json file"
-    /usr/bin/curl --location --max-time 3 --silent "$online_json_url" --output "$json_cache"
+    /usr/bin/curl --location --max-time 3 --silent --header "User-Agent: $user_agent" "$online_json_url" --output "$json_cache"
 else
     echo "No e-tag cached, proceeding to download SOFA json file"
-    /usr/bin/curl --location --max-time 3 --silent "$online_json_url" --etag-save "$etag_cache" --output "$json_cache"
+    /usr/bin/curl --location --max-time 3 --silent --header "User-Agent: $user_agent" "$online_json_url" --etag-save "$etag_cache" --output "$json_cache"
 fi
 
 echo

--- a/tool-scripts/macOSVersionCheck-EA.sh
+++ b/tool-scripts/macOSVersionCheck-EA.sh
@@ -14,6 +14,7 @@ autoload is-at-least
 
 # URL to the online JSON data
 online_json_url="https://sofa.macadmins.io/v1/macos_data_feed.json"
+user_agent="SOFA-Jamf-EA-macOSVersionCheck/1.0"
 
 # local store
 json_cache_dir="/private/tmp/sofa"
@@ -25,15 +26,15 @@ etag_cache="$json_cache_dir/macos_data_feed_etag.txt"
 
 # check local vs online using etag
 if [[ -f "$etag_cache" && -f "$json_cache" ]]; then
-    if /usr/bin/curl --silent --etag-compare "$etag_cache" "$online_json_url" --output /dev/null; then
+    if /usr/bin/curl --silent --etag-compare "$etag_cache" --header "User-Agent: $user_agent" "$online_json_url" --output /dev/null; then
         echo "Cached e-tag matches online e-tag - cached json file is up to date"
     else
         echo "Cached e-tag does not match online e-tag, proceeding to download SOFA json file"
-        /usr/bin/curl --location --max-time 3 --silent "$online_json_url" --etag-save "$etag_cache" --output "$json_cache"
+        /usr/bin/curl --location --max-time 3 --silent --header "User-Agent: $user_agent" "$online_json_url" --etag-save "$etag_cache" --output "$json_cache"
     fi
 else
     echo "No e-tag cached, proceeding to download SOFA json file"
-    /usr/bin/curl --location --max-time 3 --silent "$online_json_url" --etag-save "$etag_cache" --output "$json_cache"
+    /usr/bin/curl --location --max-time 3 --silent --header "User-Agent: $user_agent" "$online_json_url" --etag-save "$etag_cache" --output "$json_cache"
 fi
 
 echo


### PR DESCRIPTION
This adds individual user-agent strings to the `curl` requests in each of the EAs so that the requests from the "official" EAs can be seen.