### PR TITLE
update feed URL in all the tool-scripts

### DIFF
--- a/tool-scripts/GoogleSheet.gs
+++ b/tool-scripts/GoogleSheet.gs
@@ -8,7 +8,7 @@ function onOpen() {
 
 function fetchJsonAndPopulateSheet() {
   Logger.log('Starting fetchJsonAndPopulateSheet function.');
-  var url = 'https://sofa.macadmins.io/v1/macos_data_feed.json';
+  var url = 'https://sofafeed.macadmins.io/v1/macos_data_feed.json';
   
   var sheet = SpreadsheetApp.getActiveSpreadsheet().getActiveSheet();
   sheet.clear();

--- a/tool-scripts/ReadMe.md
+++ b/tool-scripts/ReadMe.md
@@ -10,7 +10,7 @@ However, SOFA provides a list of the latest available versions of macOS which ca
 
 This script can be used as an Extension Attribute in Jamf Pro to report whether macOS is up to date. It requires macOS 12 or above.
 
-Since SOFA includes hardware compatibility data for all available software updates, this script uses that information to find out what is the current latest available compatible version of macOS for the system on which the script is running, and compares that with the current system. 
+Since SOFA includes hardware compatibility data for all available software updates, this script uses that information to find out what is the current latest available compatible version of macOS for the system on which the script is running, and compares that with the current system.
 
 Here's a breakdown of what it does:
 
@@ -60,7 +60,7 @@ Here's a breakdown of what it does:
 
 2. It determines the hardware model using `/usr/sbin/sysctl -n hw.model`.
 
-3. It retrieves the current latest available macOS version from the JSON file that is compatible with the current system, then uses `plutil` to extract the version string. 
+3. It retrieves the current latest available macOS version from the JSON file that is compatible with the current system, then uses `plutil` to extract the version string.
 
 4. It compares the latest available version of macOS with the latest available macOS version that is compatible on the system, as reported in the SOFA JSON file. If they match, it returns `<result>Pass</result>`, indicating that the system can support the latest version of maCOS. Otherwise, it returns `<result>Fail</result>`.
 

--- a/tool-scripts/XProtectVersionCheck-EA.sh
+++ b/tool-scripts/XProtectVersionCheck-EA.sh
@@ -12,7 +12,7 @@
 autoload is-at-least
 
 # URL to the online JSON data
-online_json_url="https://sofa.macadmins.io/v1/macos_data_feed.json"
+online_json_url="https://sofafeed.macadmins.io/v1/macos_data_feed.json"
 user_agent="SOFA-Jamf-EA-XProtectVersionCheck/1.0"
 
 # local store

--- a/tool-scripts/XProtectVersionCheck-swiftDialog.sh
+++ b/tool-scripts/XProtectVersionCheck-swiftDialog.sh
@@ -8,7 +8,7 @@ local_app_info="/Library/Apple/System/Library/CoreServices/XProtect.app/Contents
 swiftDialog_command="/usr/local/bin/dialog" # Path to swiftDialog installation
 
 # URL to the online JSON data
-online_json_url="https://sofa.macadmins.io/v1/macos_data_feed.json"
+online_json_url="https://sofafeed.macadmins.io/v1/macos_data_feed.json"
 user_agent="SOFA-dialog-XProtectVersionCheck/1.0"
 
 # local store

--- a/tool-scripts/macOSCVECheck-EA.sh
+++ b/tool-scripts/macOSCVECheck-EA.sh
@@ -20,7 +20,7 @@
 autoload is-at-least
 
 # URL to the online JSON data
-online_json_url="https://sofa.macadmins.io/v1/macos_data_feed.json"
+online_json_url="https://sofafeed.macadmins.io/v1/macos_data_feed.json"
 user_agent="SOFA-Jamf-EA-macOSCVECheck/1.0"
 
 # local store

--- a/tool-scripts/macOSCompatibilityCheck-EA.sh
+++ b/tool-scripts/macOSCompatibilityCheck-EA.sh
@@ -25,7 +25,7 @@ else
 fi
 
 # URL to the online JSON data
-online_json_url="https://sofa.macadmins.io/v1/macos_data_feed.json"
+online_json_url="https://sofafeed.macadmins.io/v1/macos_data_feed.json"
 user_agent="SOFA-Jamf-EA-macOSCompatibilityCheck/1.0"
 
 # local store

--- a/tool-scripts/macOSVersionCheck-EA.sh
+++ b/tool-scripts/macOSVersionCheck-EA.sh
@@ -13,7 +13,7 @@
 autoload is-at-least
 
 # URL to the online JSON data
-online_json_url="https://sofa.macadmins.io/v1/macos_data_feed.json"
+online_json_url="https://sofafeed.macadmins.io/v1/macos_data_feed.json"
 user_agent="SOFA-Jamf-EA-macOSVersionCheck/1.0"
 
 # local store


### PR DESCRIPTION
This updates the URLs to `sofafeed` in all the Extension Attribute scripts plus the Google Sheets and SwiftDialog example scripts.