### PR TITLE
Change docker file to copy model_identifier_*.json from cache now

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -41,7 +41,7 @@ COPY cache/supported_devices.json /app/cache/supported_devices.json
 RUN touch time-series.csv || true
 COPY time-series.csv /app/
 
-COPY model_identifier_*.json /app/
+COPY cache/model_identifier_*.json /app/
 
 # Install Python dependencies
 RUN pip install --no-cache-dir -r requirements.txt


### PR DESCRIPTION
The `model_identifier_*.json` files reside in the cache folder to be used in the web UI for a while now. 
In our Docker workflow, we should now use the same files to avoid drift.