### PR TITLE
Use a different schedule for CVE fetching to avoid collisions.

### DIFF
--- a/.github/workflows/fetch_cve_details.yml
+++ b/.github/workflows/fetch_cve_details.yml
@@ -3,7 +3,7 @@ name: Fetch CVE Details
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 20 * * *' 
+    - cron: '45 20,6 * * *' 
 
 jobs:
   fetch_cve_details:


### PR DESCRIPTION
Automated runs for the [fetch_cve_details.yml](https://github.com/macadmins/sofa/blob/main/.github/workflows/fetch_cve_details.yml) action did fail few times. 

Set to different schedules might be resolve this, as manual runs have been running fine. 