### PR TITLE
Fix curl etag handling

### DIFF
--- a/tool-scripts/XProtectVersionCheck-EA.sh
+++ b/tool-scripts/XProtectVersionCheck-EA.sh
@@ -13,7 +13,7 @@ autoload is-at-least
 
 # URL to the online JSON data
 online_json_url="https://sofafeed.macadmins.io/v1/macos_data_feed.json"
-user_agent="SOFA-Jamf-EA-macOSVersionCheck/1.0"
+user_agent="SOFA-Jamf-EA-XProtectVersionCheck/1.0"
 
 # local store
 json_cache_dir="/private/tmp/sofa"

--- a/tool-scripts/XProtectVersionCheck-EA.sh
+++ b/tool-scripts/XProtectVersionCheck-EA.sh
@@ -32,8 +32,6 @@ if [[ -f "$etag_cache_old" && -f "$json_cache" ]]; then
     etag_new=$(/bin/cat "$etag_cache_new")
     if [[ -f "$etag_cache_new" && "$etag_new" == "" ]] || [[ "$etag_old" == "$etag_new" ]]; then
         echo "Cached ETag matched online ETag - cached json file is up to date"
-    elif [[ "$etag_old" == "$etag_new" ]]; then
-        echo "Cached ETag matched online ETag - cached json file is up to date"
     else
         echo "Cached ETag did not match online ETag, so downloaded new SOFA json file"
         echo "$etag_new" > "$etag_cache_old"

--- a/tool-scripts/XProtectVersionCheck-EA.sh
+++ b/tool-scripts/XProtectVersionCheck-EA.sh
@@ -13,30 +13,34 @@ autoload is-at-least
 
 # URL to the online JSON data
 online_json_url="https://sofafeed.macadmins.io/v1/macos_data_feed.json"
-user_agent="SOFA-Jamf-EA-XProtectVersionCheck/1.0"
+user_agent="SOFA-Jamf-EA-macOSVersionCheck/1.0"
 
 # local store
 json_cache_dir="/private/tmp/sofa"
 json_cache="$json_cache_dir/macos_data_feed.json"
-etag_cache="$json_cache_dir/macos_data_feed_etag.txt"
+etag_cache_old="$json_cache_dir/macos_data_feed_etag_old.txt"
+etag_cache_new="$json_cache_dir/macos_data_feed_etag_new.txt"
 
 # ensure local cache folder exists
 /bin/mkdir -p "$json_cache_dir"
 
 # check local vs online using etag
-if [[ -f "$etag_cache" && -f "$json_cache" ]]; then
+if [[ -f "$etag_cache_old" && -f "$json_cache" ]]; then
     echo "e-tag stored, will download only if e-tag doesn't match"
-    etag_old=$(/bin/cat "$etag_cache")
-    /usr/bin/curl --compressed --silent --etag-compare "$etag_cache" --etag-save "$etag_cache" --header "User-Agent: $user_agent" "$online_json_url" --output "$json_cache"
-    etag_new=$(/bin/cat "$etag_cache")
-    if [[ "$etag_old" == "$etag_new" ]]; then
+    etag_old=$(/bin/cat "$etag_cache_old")
+    /usr/bin/curl --compressed --silent --etag-compare "$etag_cache_old" --etag-save "$etag_cache_new" --header "User-Agent: $user_agent" "$online_json_url" --output "$json_cache"
+    etag_new=$(/bin/cat "$etag_cache_new")
+    if [[ -f "$etag_cache_new" && "$etag_new" == "" ]] || [[ "$etag_old" == "$etag_new" ]]; then
+        echo "Cached ETag matched online ETag - cached json file is up to date"
+    elif [[ "$etag_old" == "$etag_new" ]]; then
         echo "Cached ETag matched online ETag - cached json file is up to date"
     else
         echo "Cached ETag did not match online ETag, so downloaded new SOFA json file"
+        echo "$etag_new" > "$etag_cache_old"
     fi
 else
-    echo "No e-tag cached, proceeding to download SOFA json file"
-    /usr/bin/curl --compressed --location --max-time 3 --silent --header "User-Agent: $user_agent" "$online_json_url" --etag-save "$etag_cache" --output "$json_cache"
+    echo "No e-tag or SOFA json file cached, proceeding to download SOFA json file"
+    /usr/bin/curl --compressed --location --max-time 3 --silent --header "User-Agent: $user_agent" "$online_json_url" --etag-save "$etag_cache_old" --output "$json_cache"
 fi
 
 echo

--- a/tool-scripts/XProtectVersionCheck-EA.sh
+++ b/tool-scripts/XProtectVersionCheck-EA.sh
@@ -13,7 +13,7 @@ autoload is-at-least
 
 # URL to the online JSON data
 online_json_url="https://sofafeed.macadmins.io/v1/macos_data_feed.json"
-user_agent="SOFA-Jamf-EA-XProtectVersionCheck/1.0"
+user_agent="SOFA-Jamf-EA-XProtectVersionCheck/1.1"
 
 # local store
 json_cache_dir="/private/tmp/sofa"

--- a/tool-scripts/XProtectVersionCheck-EA.sh
+++ b/tool-scripts/XProtectVersionCheck-EA.sh
@@ -18,27 +18,27 @@ user_agent="SOFA-Jamf-EA-XProtectVersionCheck/1.0"
 # local store
 json_cache_dir="/private/tmp/sofa"
 json_cache="$json_cache_dir/macos_data_feed.json"
-etag_cache_old="$json_cache_dir/macos_data_feed_etag_old.txt"
-etag_cache_new="$json_cache_dir/macos_data_feed_etag_new.txt"
+etag_cache="$json_cache_dir/macos_data_feed_etag.txt"
+etag_cache_temp="$json_cache_dir/macos_data_feed_etag_temp.txt"
 
 # ensure local cache folder exists
 /bin/mkdir -p "$json_cache_dir"
 
-# check local vs online using etag
-if [[ -f "$etag_cache_old" && -f "$json_cache" ]]; then
-    echo "e-tag stored, will download only if e-tag doesn't match"
-    etag_old=$(/bin/cat "$etag_cache_old")
-    /usr/bin/curl --compressed --silent --etag-compare "$etag_cache_old" --etag-save "$etag_cache_new" --header "User-Agent: $user_agent" "$online_json_url" --output "$json_cache"
-    etag_new=$(/bin/cat "$etag_cache_new")
-    if [[ -f "$etag_cache_new" && "$etag_new" == "" ]] || [[ "$etag_old" == "$etag_new" ]]; then
+# check local vs online using etag (only available on macOS 12+)
+if [[ -f "$etag_cache" && -f "$json_cache" ]]; then
+    etag_old=$(/bin/cat "$etag_cache")
+    /usr/bin/curl --compressed --silent --etag-compare "$etag_cache" --etag-save "$etag_cache_temp" --header "User-Agent: $user_agent" "$online_json_url" --output "$json_cache"
+    etag_temp=$(/bin/cat "$etag_cache_temp")
+    if [[ "$etag_old" == "$etag_temp" || $etag_temp == "" ]]; then
         echo "Cached ETag matched online ETag - cached json file is up to date"
+        /bin/rm "$etag_cache_temp"
     else
         echo "Cached ETag did not match online ETag, so downloaded new SOFA json file"
-        echo "$etag_new" > "$etag_cache_old"
+        /bin/mv "$etag_cache_temp" "$etag_cache"
     fi
 else
     echo "No e-tag or SOFA json file cached, proceeding to download SOFA json file"
-    /usr/bin/curl --compressed --location --max-time 3 --silent --header "User-Agent: $user_agent" "$online_json_url" --etag-save "$etag_cache_old" --output "$json_cache"
+    /usr/bin/curl --compressed --location --max-time 3 --silent --header "User-Agent: $user_agent" "$online_json_url" --etag-save "$etag_cache" --output "$json_cache"
 fi
 
 echo

--- a/tool-scripts/XProtectVersionCheck-swiftDialog.sh
+++ b/tool-scripts/XProtectVersionCheck-swiftDialog.sh
@@ -9,30 +9,34 @@ swiftDialog_command="/usr/local/bin/dialog" # Path to swiftDialog installation
 
 # URL to the online JSON data
 online_json_url="https://sofafeed.macadmins.io/v1/macos_data_feed.json"
-user_agent="SOFA-dialog-XProtectVersionCheck/1.0"
+user_agent="SOFA-Jamf-EA-macOSVersionCheck/1.0"
 
 # local store
 json_cache_dir="/private/tmp/sofa"
 json_cache="$json_cache_dir/macos_data_feed.json"
-etag_cache="$json_cache_dir/macos_data_feed_etag.txt"
+etag_cache_old="$json_cache_dir/macos_data_feed_etag_old.txt"
+etag_cache_new="$json_cache_dir/macos_data_feed_etag_new.txt"
 
 # ensure local cache folder exists
 /bin/mkdir -p "$json_cache_dir"
 
 # check local vs online using etag
-if [[ -f "$etag_cache" && -f "$json_cache" ]]; then
+if [[ -f "$etag_cache_old" && -f "$json_cache" ]]; then
     echo "e-tag stored, will download only if e-tag doesn't match"
-    etag_old=$(/bin/cat "$etag_cache")
-    /usr/bin/curl --compressed --silent --etag-compare "$etag_cache" --etag-save "$etag_cache" --header "User-Agent: $user_agent" "$online_json_url" --output "$json_cache"
-    etag_new=$(/bin/cat "$etag_cache")
-    if [[ "$etag_old" == "$etag_new" ]]; then
+    etag_old=$(/bin/cat "$etag_cache_old")
+    /usr/bin/curl --compressed --silent --etag-compare "$etag_cache_old" --etag-save "$etag_cache_new" --header "User-Agent: $user_agent" "$online_json_url" --output "$json_cache"
+    etag_new=$(/bin/cat "$etag_cache_new")
+    if [[ -f "$etag_cache_new" && "$etag_new" == "" ]] || [[ "$etag_old" == "$etag_new" ]]; then
+        echo "Cached ETag matched online ETag - cached json file is up to date"
+    elif [[ "$etag_old" == "$etag_new" ]]; then
         echo "Cached ETag matched online ETag - cached json file is up to date"
     else
         echo "Cached ETag did not match online ETag, so downloaded new SOFA json file"
+        echo "$etag_new" > "$etag_cache_old"
     fi
 else
-    echo "No e-tag cached, proceeding to download SOFA json file"
-    /usr/bin/curl --compressed --location --max-time 3 --silent --header "User-Agent: $user_agent" "$online_json_url" --etag-save "$etag_cache" --output "$json_cache"
+    echo "No e-tag or SOFA json file cached, proceeding to download SOFA json file"
+    /usr/bin/curl --compressed --location --max-time 3 --silent --header "User-Agent: $user_agent" "$online_json_url" --etag-save "$etag_cache_old" --output "$json_cache"
 fi
 
 echo

--- a/tool-scripts/XProtectVersionCheck-swiftDialog.sh
+++ b/tool-scripts/XProtectVersionCheck-swiftDialog.sh
@@ -9,7 +9,7 @@ swiftDialog_command="/usr/local/bin/dialog" # Path to swiftDialog installation
 
 # URL to the online JSON data
 online_json_url="https://sofafeed.macadmins.io/v1/macos_data_feed.json"
-user_agent="SOFA-dialog-XProtectVersionCheck/1.0"
+user_agent="SOFA-dialog-XProtectVersionCheck/1.1"
 
 # local store
 json_cache_dir="/private/tmp/sofa"

--- a/tool-scripts/XProtectVersionCheck-swiftDialog.sh
+++ b/tool-scripts/XProtectVersionCheck-swiftDialog.sh
@@ -28,8 +28,6 @@ if [[ -f "$etag_cache_old" && -f "$json_cache" ]]; then
     etag_new=$(/bin/cat "$etag_cache_new")
     if [[ -f "$etag_cache_new" && "$etag_new" == "" ]] || [[ "$etag_old" == "$etag_new" ]]; then
         echo "Cached ETag matched online ETag - cached json file is up to date"
-    elif [[ "$etag_old" == "$etag_new" ]]; then
-        echo "Cached ETag matched online ETag - cached json file is up to date"
     else
         echo "Cached ETag did not match online ETag, so downloaded new SOFA json file"
         echo "$etag_new" > "$etag_cache_old"

--- a/tool-scripts/XProtectVersionCheck-swiftDialog.sh
+++ b/tool-scripts/XProtectVersionCheck-swiftDialog.sh
@@ -9,7 +9,7 @@ swiftDialog_command="/usr/local/bin/dialog" # Path to swiftDialog installation
 
 # URL to the online JSON data
 online_json_url="https://sofafeed.macadmins.io/v1/macos_data_feed.json"
-user_agent="SOFA-Jamf-EA-macOSVersionCheck/1.0"
+user_agent="SOFA-dialog-XProtectVersionCheck/1.0"
 
 # local store
 json_cache_dir="/private/tmp/sofa"

--- a/tool-scripts/XProtectVersionCheck-swiftDialog.sh
+++ b/tool-scripts/XProtectVersionCheck-swiftDialog.sh
@@ -14,27 +14,27 @@ user_agent="SOFA-dialog-XProtectVersionCheck/1.0"
 # local store
 json_cache_dir="/private/tmp/sofa"
 json_cache="$json_cache_dir/macos_data_feed.json"
-etag_cache_old="$json_cache_dir/macos_data_feed_etag_old.txt"
-etag_cache_new="$json_cache_dir/macos_data_feed_etag_new.txt"
+etag_cache="$json_cache_dir/macos_data_feed_etag.txt"
+etag_cache_temp="$json_cache_dir/macos_data_feed_etag_temp.txt"
 
 # ensure local cache folder exists
 /bin/mkdir -p "$json_cache_dir"
 
-# check local vs online using etag
-if [[ -f "$etag_cache_old" && -f "$json_cache" ]]; then
-    echo "e-tag stored, will download only if e-tag doesn't match"
-    etag_old=$(/bin/cat "$etag_cache_old")
-    /usr/bin/curl --compressed --silent --etag-compare "$etag_cache_old" --etag-save "$etag_cache_new" --header "User-Agent: $user_agent" "$online_json_url" --output "$json_cache"
-    etag_new=$(/bin/cat "$etag_cache_new")
-    if [[ -f "$etag_cache_new" && "$etag_new" == "" ]] || [[ "$etag_old" == "$etag_new" ]]; then
+# check local vs online using etag (only available on macOS 12+)
+if [[ -f "$etag_cache" && -f "$json_cache" ]]; then
+    etag_old=$(/bin/cat "$etag_cache")
+    /usr/bin/curl --compressed --silent --etag-compare "$etag_cache" --etag-save "$etag_cache_temp" --header "User-Agent: $user_agent" "$online_json_url" --output "$json_cache"
+    etag_temp=$(/bin/cat "$etag_cache_temp")
+    if [[ "$etag_old" == "$etag_temp" || $etag_temp == "" ]]; then
         echo "Cached ETag matched online ETag - cached json file is up to date"
+        /bin/rm "$etag_cache_temp"
     else
         echo "Cached ETag did not match online ETag, so downloaded new SOFA json file"
-        echo "$etag_new" > "$etag_cache_old"
+        /bin/mv "$etag_cache_temp" "$etag_cache"
     fi
 else
     echo "No e-tag or SOFA json file cached, proceeding to download SOFA json file"
-    /usr/bin/curl --compressed --location --max-time 3 --silent --header "User-Agent: $user_agent" "$online_json_url" --etag-save "$etag_cache_old" --output "$json_cache"
+    /usr/bin/curl --compressed --location --max-time 3 --silent --header "User-Agent: $user_agent" "$online_json_url" --etag-save "$etag_cache" --output "$json_cache"
 fi
 
 echo

--- a/tool-scripts/macOSCVECheck-EA.sh
+++ b/tool-scripts/macOSCVECheck-EA.sh
@@ -21,7 +21,7 @@ autoload is-at-least
 
 # URL to the online JSON data
 online_json_url="https://sofafeed.macadmins.io/v1/macos_data_feed.json"
-user_agent="SOFA-Jamf-EA-macOSCVECheck/1.0"
+user_agent="SOFA-Jamf-EA-macOSCVECheck/1.1"
 
 # local store
 json_cache_dir="/private/tmp/sofa"

--- a/tool-scripts/macOSCVECheck-EA.sh
+++ b/tool-scripts/macOSCVECheck-EA.sh
@@ -21,30 +21,34 @@ autoload is-at-least
 
 # URL to the online JSON data
 online_json_url="https://sofafeed.macadmins.io/v1/macos_data_feed.json"
-user_agent="SOFA-Jamf-EA-macOSCVECheck/1.0"
+user_agent="SOFA-Jamf-EA-macOSVersionCheck/1.0"
 
 # local store
 json_cache_dir="/private/tmp/sofa"
 json_cache="$json_cache_dir/macos_data_feed.json"
-etag_cache="$json_cache_dir/macos_data_feed_etag.txt"
+etag_cache_old="$json_cache_dir/macos_data_feed_etag_old.txt"
+etag_cache_new="$json_cache_dir/macos_data_feed_etag_new.txt"
 
 # ensure local cache folder exists
 /bin/mkdir -p "$json_cache_dir"
 
 # check local vs online using etag
-if [[ -f "$etag_cache" && -f "$json_cache" ]]; then
+if [[ -f "$etag_cache_old" && -f "$json_cache" ]]; then
     echo "e-tag stored, will download only if e-tag doesn't match"
-    etag_old=$(/bin/cat "$etag_cache")
-    /usr/bin/curl --compressed --silent --etag-compare "$etag_cache" --etag-save "$etag_cache" --header "User-Agent: $user_agent" "$online_json_url" --output "$json_cache"
-    etag_new=$(/bin/cat "$etag_cache")
-    if [[ "$etag_old" == "$etag_new" ]]; then
+    etag_old=$(/bin/cat "$etag_cache_old")
+    /usr/bin/curl --compressed --silent --etag-compare "$etag_cache_old" --etag-save "$etag_cache_new" --header "User-Agent: $user_agent" "$online_json_url" --output "$json_cache"
+    etag_new=$(/bin/cat "$etag_cache_new")
+    if [[ -f "$etag_cache_new" && "$etag_new" == "" ]] || [[ "$etag_old" == "$etag_new" ]]; then
+        echo "Cached ETag matched online ETag - cached json file is up to date"
+    elif [[ "$etag_old" == "$etag_new" ]]; then
         echo "Cached ETag matched online ETag - cached json file is up to date"
     else
         echo "Cached ETag did not match online ETag, so downloaded new SOFA json file"
+        echo "$etag_new" > "$etag_cache_old"
     fi
 else
-    echo "No e-tag cached, proceeding to download SOFA json file"
-    /usr/bin/curl --compressed --location --max-time 3 --silent --header "User-Agent: $user_agent" "$online_json_url" --etag-save "$etag_cache" --output "$json_cache"
+    echo "No e-tag or SOFA json file cached, proceeding to download SOFA json file"
+    /usr/bin/curl --compressed --location --max-time 3 --silent --header "User-Agent: $user_agent" "$online_json_url" --etag-save "$etag_cache_old" --output "$json_cache"
 fi
 
 echo

--- a/tool-scripts/macOSCVECheck-EA.sh
+++ b/tool-scripts/macOSCVECheck-EA.sh
@@ -21,7 +21,7 @@ autoload is-at-least
 
 # URL to the online JSON data
 online_json_url="https://sofafeed.macadmins.io/v1/macos_data_feed.json"
-user_agent="SOFA-Jamf-EA-macOSVersionCheck/1.0"
+user_agent="SOFA-Jamf-EA-macOSCVECheck/1.0"
 
 # local store
 json_cache_dir="/private/tmp/sofa"

--- a/tool-scripts/macOSCVECheck-EA.sh
+++ b/tool-scripts/macOSCVECheck-EA.sh
@@ -40,8 +40,6 @@ if [[ -f "$etag_cache_old" && -f "$json_cache" ]]; then
     etag_new=$(/bin/cat "$etag_cache_new")
     if [[ -f "$etag_cache_new" && "$etag_new" == "" ]] || [[ "$etag_old" == "$etag_new" ]]; then
         echo "Cached ETag matched online ETag - cached json file is up to date"
-    elif [[ "$etag_old" == "$etag_new" ]]; then
-        echo "Cached ETag matched online ETag - cached json file is up to date"
     else
         echo "Cached ETag did not match online ETag, so downloaded new SOFA json file"
         echo "$etag_new" > "$etag_cache_old"

--- a/tool-scripts/macOSCVECheck-EA.sh
+++ b/tool-scripts/macOSCVECheck-EA.sh
@@ -26,27 +26,27 @@ user_agent="SOFA-Jamf-EA-macOSCVECheck/1.0"
 # local store
 json_cache_dir="/private/tmp/sofa"
 json_cache="$json_cache_dir/macos_data_feed.json"
-etag_cache_old="$json_cache_dir/macos_data_feed_etag_old.txt"
-etag_cache_new="$json_cache_dir/macos_data_feed_etag_new.txt"
+etag_cache="$json_cache_dir/macos_data_feed_etag.txt"
+etag_cache_temp="$json_cache_dir/macos_data_feed_etag_temp.txt"
 
 # ensure local cache folder exists
 /bin/mkdir -p "$json_cache_dir"
 
-# check local vs online using etag
-if [[ -f "$etag_cache_old" && -f "$json_cache" ]]; then
-    echo "e-tag stored, will download only if e-tag doesn't match"
-    etag_old=$(/bin/cat "$etag_cache_old")
-    /usr/bin/curl --compressed --silent --etag-compare "$etag_cache_old" --etag-save "$etag_cache_new" --header "User-Agent: $user_agent" "$online_json_url" --output "$json_cache"
-    etag_new=$(/bin/cat "$etag_cache_new")
-    if [[ -f "$etag_cache_new" && "$etag_new" == "" ]] || [[ "$etag_old" == "$etag_new" ]]; then
+# check local vs online using etag (only available on macOS 12+)
+if [[ -f "$etag_cache" && -f "$json_cache" ]]; then
+    etag_old=$(/bin/cat "$etag_cache")
+    /usr/bin/curl --compressed --silent --etag-compare "$etag_cache" --etag-save "$etag_cache_temp" --header "User-Agent: $user_agent" "$online_json_url" --output "$json_cache"
+    etag_temp=$(/bin/cat "$etag_cache_temp")
+    if [[ "$etag_old" == "$etag_temp" || $etag_temp == "" ]]; then
         echo "Cached ETag matched online ETag - cached json file is up to date"
+        /bin/rm "$etag_cache_temp"
     else
         echo "Cached ETag did not match online ETag, so downloaded new SOFA json file"
-        echo "$etag_new" > "$etag_cache_old"
+        /bin/mv "$etag_cache_temp" "$etag_cache"
     fi
 else
     echo "No e-tag or SOFA json file cached, proceeding to download SOFA json file"
-    /usr/bin/curl --compressed --location --max-time 3 --silent --header "User-Agent: $user_agent" "$online_json_url" --etag-save "$etag_cache_old" --output "$json_cache"
+    /usr/bin/curl --compressed --location --max-time 3 --silent --header "User-Agent: $user_agent" "$online_json_url" --etag-save "$etag_cache" --output "$json_cache"
 fi
 
 echo

--- a/tool-scripts/macOSCompatibilityCheck-EA.sh
+++ b/tool-scripts/macOSCompatibilityCheck-EA.sh
@@ -37,7 +37,7 @@ etag_cache_new="$json_cache_dir/macos_data_feed_etag_new.txt"
 # ensure local cache folder exists
 /bin/mkdir -p "$json_cache_dir"
 
-# check local vs online using etag
+# check local vs online using etag (only available on macOS 12+)
 if [[ -f "$etag_cache_old" && -f "$json_cache" ]]; then
     echo "e-tag stored, will download only if e-tag doesn't match"
     etag_old=$(/bin/cat "$etag_cache_old")
@@ -49,6 +49,9 @@ if [[ -f "$etag_cache_old" && -f "$json_cache" ]]; then
         echo "Cached ETag did not match online ETag, so downloaded new SOFA json file"
         echo "$etag_new" > "$etag_cache_old"
     fi
+elif [[ "$os_compatibility" == "legacy" ]]; then
+    echo "OS not compatible with e-tags, proceeding to download SOFA json file"
+    /usr/bin/curl --compressed --location --max-time 3 --silent --header "User-Agent: $user_agent" "$online_json_url" --output "$json_cache"
 else
     echo "No e-tag or SOFA json file cached, proceeding to download SOFA json file"
     /usr/bin/curl --compressed --location --max-time 3 --silent --header "User-Agent: $user_agent" "$online_json_url" --etag-save "$etag_cache_old" --output "$json_cache"

--- a/tool-scripts/macOSCompatibilityCheck-EA.sh
+++ b/tool-scripts/macOSCompatibilityCheck-EA.sh
@@ -26,7 +26,7 @@ fi
 
 # URL to the online JSON data
 online_json_url="https://sofafeed.macadmins.io/v1/macos_data_feed.json"
-user_agent="SOFA-Jamf-EA-macOSCompatibilityCheck/1.0"
+user_agent="SOFA-Jamf-EA-macOSCompatibilityCheck/1.1"
 
 # local store
 json_cache_dir="/private/tmp/sofa"

--- a/tool-scripts/macOSCompatibilityCheck-EA.sh
+++ b/tool-scripts/macOSCompatibilityCheck-EA.sh
@@ -26,7 +26,7 @@ fi
 
 # URL to the online JSON data
 online_json_url="https://sofafeed.macadmins.io/v1/macos_data_feed.json"
-user_agent="SOFA-Jamf-EA-macOSVersionCheck/1.0"
+user_agent="SOFA-Jamf-EA-macOSCompatibilityCheck/1.0"
 
 # local store
 json_cache_dir="/private/tmp/sofa"

--- a/tool-scripts/macOSCompatibilityCheck-EA.sh
+++ b/tool-scripts/macOSCompatibilityCheck-EA.sh
@@ -45,8 +45,6 @@ if [[ -f "$etag_cache_old" && -f "$json_cache" ]]; then
     etag_new=$(/bin/cat "$etag_cache_new")
     if [[ -f "$etag_cache_new" && "$etag_new" == "" ]] || [[ "$etag_old" == "$etag_new" ]]; then
         echo "Cached ETag matched online ETag - cached json file is up to date"
-    elif [[ "$etag_old" == "$etag_new" ]]; then
-        echo "Cached ETag matched online ETag - cached json file is up to date"
     else
         echo "Cached ETag did not match online ETag, so downloaded new SOFA json file"
         echo "$etag_new" > "$etag_cache_old"

--- a/tool-scripts/macOSCompatibilityCheck-EA.sh
+++ b/tool-scripts/macOSCompatibilityCheck-EA.sh
@@ -26,33 +26,34 @@ fi
 
 # URL to the online JSON data
 online_json_url="https://sofafeed.macadmins.io/v1/macos_data_feed.json"
-user_agent="SOFA-Jamf-EA-macOSCompatibilityCheck/1.0"
+user_agent="SOFA-Jamf-EA-macOSVersionCheck/1.0"
 
 # local store
 json_cache_dir="/private/tmp/sofa"
 json_cache="$json_cache_dir/macos_data_feed.json"
-etag_cache="$json_cache_dir/macos_data_feed_etag.txt"
+etag_cache_old="$json_cache_dir/macos_data_feed_etag_old.txt"
+etag_cache_new="$json_cache_dir/macos_data_feed_etag_new.txt"
 
 # ensure local cache folder exists
 /bin/mkdir -p "$json_cache_dir"
 
-# check local vs online using etag (only available on macOS 12+)
-if [[ -f "$etag_cache" && -f "$json_cache" ]]; then
-    etag_old=$(/bin/cat "$etag_cache")
-    /usr/bin/curl --compressed --silent --etag-compare "$etag_cache" --etag-save "$etag_cache" --header "User-Agent: $user_agent" "$online_json_url" --output "$json_cache"
-    etag_new=$(/bin/cat "$etag_cache")
-    if [[ "$etag_old" == "$etag_new" ]]; then
+# check local vs online using etag
+if [[ -f "$etag_cache_old" && -f "$json_cache" ]]; then
+    echo "e-tag stored, will download only if e-tag doesn't match"
+    etag_old=$(/bin/cat "$etag_cache_old")
+    /usr/bin/curl --compressed --silent --etag-compare "$etag_cache_old" --etag-save "$etag_cache_new" --header "User-Agent: $user_agent" "$online_json_url" --output "$json_cache"
+    etag_new=$(/bin/cat "$etag_cache_new")
+    if [[ -f "$etag_cache_new" && "$etag_new" == "" ]] || [[ "$etag_old" == "$etag_new" ]]; then
+        echo "Cached ETag matched online ETag - cached json file is up to date"
+    elif [[ "$etag_old" == "$etag_new" ]]; then
         echo "Cached ETag matched online ETag - cached json file is up to date"
     else
         echo "Cached ETag did not match online ETag, so downloaded new SOFA json file"
+        echo "$etag_new" > "$etag_cache_old"
     fi
-
-elif [[ "$os_compatibility" == "legacy" ]]; then
-    echo "OS not compatible with e-tags, proceeding to download SOFA json file"
-    /usr/bin/curl --compressed --location --max-time 3 --silent --header "User-Agent: $user_agent" "$online_json_url" --output "$json_cache"
 else
-    echo "No e-tag cached, proceeding to download SOFA json file"
-    /usr/bin/curl --compressed --location --max-time 3 --silent --header "User-Agent: $user_agent" "$online_json_url" --etag-save "$etag_cache" --output "$json_cache"
+    echo "No e-tag or SOFA json file cached, proceeding to download SOFA json file"
+    /usr/bin/curl --compressed --location --max-time 3 --silent --header "User-Agent: $user_agent" "$online_json_url" --etag-save "$etag_cache_old" --output "$json_cache"
 fi
 
 echo

--- a/tool-scripts/macOSVersionCheck-EA.sh
+++ b/tool-scripts/macOSVersionCheck-EA.sh
@@ -19,25 +19,29 @@ user_agent="SOFA-Jamf-EA-macOSVersionCheck/1.0"
 # local store
 json_cache_dir="/private/tmp/sofa"
 json_cache="$json_cache_dir/macos_data_feed.json"
-etag_cache="$json_cache_dir/macos_data_feed_etag.txt"
+etag_cache_old="$json_cache_dir/macos_data_feed_etag_old.txt"
+etag_cache_new="$json_cache_dir/macos_data_feed_etag_new.txt"
 
 # ensure local cache folder exists
 /bin/mkdir -p "$json_cache_dir"
 
 # check local vs online using etag
-if [[ -f "$etag_cache" && -f "$json_cache" ]]; then
+if [[ -f "$etag_cache_old" && -f "$json_cache" ]]; then
     echo "e-tag stored, will download only if e-tag doesn't match"
-    etag_old=$(/bin/cat "$etag_cache")
-    /usr/bin/curl --compressed --silent --etag-compare "$etag_cache" --etag-save "$etag_cache" --header "User-Agent: $user_agent" "$online_json_url" --output "$json_cache"
-    etag_new=$(/bin/cat "$etag_cache")
-    if [[ "$etag_old" == "$etag_new" ]]; then
+    etag_old=$(/bin/cat "$etag_cache_old")
+    /usr/bin/curl --compressed --silent --etag-compare "$etag_cache_old" --etag-save "$etag_cache_new" --header "User-Agent: $user_agent" "$online_json_url" --output "$json_cache"
+    etag_new=$(/bin/cat "$etag_cache_new")
+    if [[ -f "$etag_cache_new" && "$etag_new" == "" ]] || [[ "$etag_old" == "$etag_new" ]]; then
+        echo "Cached ETag matched online ETag - cached json file is up to date"
+    elif [[ "$etag_old" == "$etag_new" ]]; then
         echo "Cached ETag matched online ETag - cached json file is up to date"
     else
         echo "Cached ETag did not match online ETag, so downloaded new SOFA json file"
+        echo "$etag_new" > "$etag_cache_old"
     fi
 else
-    echo "No e-tag cached, proceeding to download SOFA json file"
-    /usr/bin/curl --compressed --location --max-time 3 --silent --header "User-Agent: $user_agent" "$online_json_url" --etag-save "$etag_cache" --output "$json_cache"
+    echo "No e-tag or SOFA json file cached, proceeding to download SOFA json file"
+    /usr/bin/curl --compressed --location --max-time 3 --silent --header "User-Agent: $user_agent" "$online_json_url" --etag-save "$etag_cache_old" --output "$json_cache"
 fi
 
 echo

--- a/tool-scripts/macOSVersionCheck-EA.sh
+++ b/tool-scripts/macOSVersionCheck-EA.sh
@@ -33,8 +33,6 @@ if [[ -f "$etag_cache_old" && -f "$json_cache" ]]; then
     etag_new=$(/bin/cat "$etag_cache_new")
     if [[ -f "$etag_cache_new" && "$etag_new" == "" ]] || [[ "$etag_old" == "$etag_new" ]]; then
         echo "Cached ETag matched online ETag - cached json file is up to date"
-    elif [[ "$etag_old" == "$etag_new" ]]; then
-        echo "Cached ETag matched online ETag - cached json file is up to date"
     else
         echo "Cached ETag did not match online ETag, so downloaded new SOFA json file"
         echo "$etag_new" > "$etag_cache_old"

--- a/tool-scripts/macOSVersionCheck-EA.sh
+++ b/tool-scripts/macOSVersionCheck-EA.sh
@@ -19,27 +19,27 @@ user_agent="SOFA-Jamf-EA-macOSVersionCheck/1.0"
 # local store
 json_cache_dir="/private/tmp/sofa"
 json_cache="$json_cache_dir/macos_data_feed.json"
-etag_cache_old="$json_cache_dir/macos_data_feed_etag_old.txt"
-etag_cache_new="$json_cache_dir/macos_data_feed_etag_new.txt"
+etag_cache="$json_cache_dir/macos_data_feed_etag.txt"
+etag_cache_temp="$json_cache_dir/macos_data_feed_etag_temp.txt"
 
 # ensure local cache folder exists
 /bin/mkdir -p "$json_cache_dir"
 
-# check local vs online using etag
-if [[ -f "$etag_cache_old" && -f "$json_cache" ]]; then
-    echo "e-tag stored, will download only if e-tag doesn't match"
-    etag_old=$(/bin/cat "$etag_cache_old")
-    /usr/bin/curl --compressed --silent --etag-compare "$etag_cache_old" --etag-save "$etag_cache_new" --header "User-Agent: $user_agent" "$online_json_url" --output "$json_cache"
-    etag_new=$(/bin/cat "$etag_cache_new")
-    if [[ -f "$etag_cache_new" && "$etag_new" == "" ]] || [[ "$etag_old" == "$etag_new" ]]; then
+# check local vs online using etag (only available on macOS 12+)
+if [[ -f "$etag_cache" && -f "$json_cache" ]]; then
+    etag_old=$(/bin/cat "$etag_cache")
+    /usr/bin/curl --compressed --silent --etag-compare "$etag_cache" --etag-save "$etag_cache_temp" --header "User-Agent: $user_agent" "$online_json_url" --output "$json_cache"
+    etag_temp=$(/bin/cat "$etag_cache_temp")
+    if [[ "$etag_old" == "$etag_temp" || $etag_temp == "" ]]; then
         echo "Cached ETag matched online ETag - cached json file is up to date"
+        /bin/rm "$etag_cache_temp"
     else
         echo "Cached ETag did not match online ETag, so downloaded new SOFA json file"
-        echo "$etag_new" > "$etag_cache_old"
+        /bin/mv "$etag_cache_temp" "$etag_cache"
     fi
 else
     echo "No e-tag or SOFA json file cached, proceeding to download SOFA json file"
-    /usr/bin/curl --compressed --location --max-time 3 --silent --header "User-Agent: $user_agent" "$online_json_url" --etag-save "$etag_cache_old" --output "$json_cache"
+    /usr/bin/curl --compressed --location --max-time 3 --silent --header "User-Agent: $user_agent" "$online_json_url" --etag-save "$etag_cache" --output "$json_cache"
 fi
 
 echo

--- a/tool-scripts/macOSVersionCheck-EA.sh
+++ b/tool-scripts/macOSVersionCheck-EA.sh
@@ -14,7 +14,7 @@ autoload is-at-least
 
 # URL to the online JSON data
 online_json_url="https://sofafeed.macadmins.io/v1/macos_data_feed.json"
-user_agent="SOFA-Jamf-EA-macOSVersionCheck/1.0"
+user_agent="SOFA-Jamf-EA-macOSVersionCheck/1.1"
 
 # local store
 json_cache_dir="/private/tmp/sofa"


### PR DESCRIPTION
`curl` will output a 0 byte file to the `--etag-save` path if `--etag-compare` passes. From the `curl` manpage:

```
--etag-compare <file>
              (HTTP) This option makes a conditional HTTP request for the
              specific ETag read from the given file by sending a custom
              If-None-Match header using the stored ETag.

              For correct results, make sure that the specified file contains
              only a single line with the desired ETag. An empty file is
              parsed as an empty ETag.

              Use the option --etag-save to first save the ETag from a
              response, and then use this option to compare against the saved
              ETag in a subsequent request.
```

This causes the scripts to re-download the SOFA json file on every other re-run because the cached etag file (which is also the file being compared) is empty, so curl's `--etag-compare` fails with it.

Every re-run echos out the following even if curl did not re-download the SOFA json file:

```
Cached ETag did not match online ETag, so downloaded new SOFA json file
```

Curl will re-download the SOFA json file every other run (removed `--silent` flag to test):

```
% '/Users/neil.martin/Documents/GitHub/sofa/tool-scripts/XProtectVersionCheck-swiftDialog.sh'
e-tag stored, will download only if e-tag doesn't match
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
Cached ETag did not match online ETag, so downloaded new SOFA json file
```

```
% '/Users/neil.martin/Documents/GitHub/sofa/tool-scripts/XProtectVersionCheck-swiftDialog.sh'
e-tag stored, will download only if e-tag doesn't match
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 11732  100 11732    0     0   234k      0 --:--:-- --:--:-- --:--:--  238k
Cached ETag did not match online ETag, so downloaded new SOFA json file
```

This PR will ensure the following behaviour:

1. If `macos_data_feed_etag_old.txt` OR SOFA json file are not present, download the SOFA json file and store etag in `macos_data_feed_etag_old.txt`
2. If `macos_data_feed_etag_old.txt` AND the SOFA json file are present, curl and compare etag then save new etag to `macos_data_feed_etag_new.txt` - it will be 0 bytes if the comparison passes.
3. If `macos_data_feed_etag_old.txt` exists AND is 0 bytes, OR `macos_data_feed_etag_old.txt` matches `macos_data_feed_etag_new.txt`, a new json file was not downloaded, so we echo the correct output.
4. Otherwise, we did download a new SOFA json file, so we overwrite `macos_data_feed_etag_old.txt` with the contents of `macos_data_feed_etag_new.txt`