### PR TITLE
Update references to new URL

### DIFF
--- a/cache/essential_links.json
+++ b/cache/essential_links.json
@@ -24,7 +24,7 @@
     }
   },
   "Common": {
-    "Apple security releases": "https://support.apple.com/en-ca/HT201222",
+    "Apple security releases": "https://support.apple.com/en-ca/100100",
     "Apple Platform Deployment": "https://support.apple.com/en-ca/guide/deployment/dep9d814c555/1/web/1.0",
     "Apple Platform Security": "https://support.apple.com/en-ca/guide/security/secb82d6b274/web",
     "Apple Platform Certifications": "https://support.apple.com/en-ca/guide/certifications/apc353b1b736/web"
@@ -35,7 +35,7 @@
       "Apple Platform Deployment": "https://support.apple.com/en-ca/guide/deployment/welcome/web",
       "Apple Platform Security": "https://support.apple.com/en-ca/guide/security/welcome/web",
       "Apple Platform Certifications": "https://support.apple.com/en-ca/guide/certifications/welcome/web",
-      "Apple security releases": "https://support.apple.com/en-ca/HT201222",
+      "Apple security releases": "https://support.apple.com/en-ca/100100",
       "Apple products on enterprise networks": "https://support.apple.com/en-ca/101555",
       "Apple Business Manager User Guide": "https://support.apple.com/en-ca/guide/apple-business-manager/welcome/web"
     }

--- a/v1/v1_data_feed.md
+++ b/v1/v1_data_feed.md
@@ -8,9 +8,9 @@ Provides rapid access to the latest OS version details, including product versio
 
 **Integration with Security Releases:**
 
-- Source: `HT201222`
+- Source: `100100`
 
-After the OS information is updated in HT201222 (could take hours or days), the system automatically enriches the dataset with security release details, including update names, release dates, security information URLs, CVE details, and the number of days since the previous release.
+After the OS information is updated in Apple Security releases page (could take hours or days), the system automatically enriches the dataset with security release details, including update names, release dates, security information URLs, CVE details, and the number of days since the previous release.
 
 **Static Information Sources:**
 

--- a/v1/v1_data_feed.md
+++ b/v1/v1_data_feed.md
@@ -10,7 +10,7 @@ Provides rapid access to the latest OS version details, including product versio
 
 - Source: `100100`
 
-After the OS information is updated in Apple Security releases page (could take hours or days), the system automatically enriches the dataset with security release details, including update names, release dates, security information URLs, CVE details, and the number of days since the previous release.
+After the OS information is updated in Apple security releases page (could take hours or days), the system automatically enriches the dataset with security release details, including update names, release dates, security information URLs, CVE details, and the number of days since the previous release.
 
 **Static Information Sources:**
 

--- a/v1/v1_mac.schema
+++ b/v1/v1_mac.schema
@@ -6,7 +6,7 @@
       "type": "string"
     },
     "OSVersions": {
-      "description": "All macOS versions published to date that Apple has included in their security releases KB, HT201222",
+      "description": "All macOS versions published to date that Apple has included in their security releases page (formerly known as HT201222)",
       "type": "array",
       "items": {
         "type": "object",
@@ -48,7 +48,7 @@
             "required": [ "ProductVersion", "Build", "ReleaseDate", "ExpirationDate", "SupportedDevices" ]
           },
           "SecurityReleases": {
-            "description": "All OS releases tracked in HT201222, including latest",
+            "description": "All OS releases tracked in Apple security releases page, including latest",
             "type": "array",
             "items": {
               "type": "object",

--- a/web/components/SecurityInfo.vue
+++ b/web/components/SecurityInfo.vue
@@ -94,7 +94,7 @@ export default {
       tempAnchorElement.href = url;
       // Replace specific text with a generic link
       if (url === 'This update has no published CVE entries.') {
-        return 'https://support.apple.com/en-ca/HT201222';
+        return 'https://support.apple.com/en-ca/100100';
       }
       return tempAnchorElement.href;
     },


### PR DESCRIPTION
Formerly the reference was HT201222 now it's available under "https://support.apple.com/en-us/100100