### PR TITLE
relocate temp files to /var/tmp

### DIFF
--- a/tool-scripts/XProtectVersionCheck-EA.sh
+++ b/tool-scripts/XProtectVersionCheck-EA.sh
@@ -16,7 +16,7 @@ online_json_url="https://sofafeed.macadmins.io/v1/macos_data_feed.json"
 user_agent="SOFA-Jamf-EA-XProtectVersionCheck/1.1"
 
 # local store
-json_cache_dir="/var/tmp/sofa"
+json_cache_dir="/private/var/tmp/sofa"
 json_cache="$json_cache_dir/macos_data_feed.json"
 etag_cache="$json_cache_dir/macos_data_feed_etag.txt"
 etag_cache_temp="$json_cache_dir/macos_data_feed_etag_temp.txt"

--- a/tool-scripts/XProtectVersionCheck-EA.sh
+++ b/tool-scripts/XProtectVersionCheck-EA.sh
@@ -16,7 +16,7 @@ online_json_url="https://sofafeed.macadmins.io/v1/macos_data_feed.json"
 user_agent="SOFA-Jamf-EA-XProtectVersionCheck/1.1"
 
 # local store
-json_cache_dir="/private/tmp/sofa"
+json_cache_dir="/var/tmp/sofa"
 json_cache="$json_cache_dir/macos_data_feed.json"
 etag_cache="$json_cache_dir/macos_data_feed_etag.txt"
 etag_cache_temp="$json_cache_dir/macos_data_feed_etag_temp.txt"
@@ -53,6 +53,10 @@ fi
 
 # 1. Get model (DeviceID)
 model=$(/usr/sbin/sysctl -n hw.model)
+if [[ -z "$model" ]]; then
+    echo "<result>Could not obtain model</result>"
+    exit
+fi
 echo "Model Identifier: $model"
 
 # 2. Get current system OS

--- a/tool-scripts/XProtectVersionCheck-swiftDialog.sh
+++ b/tool-scripts/XProtectVersionCheck-swiftDialog.sh
@@ -12,7 +12,7 @@ online_json_url="https://sofafeed.macadmins.io/v1/macos_data_feed.json"
 user_agent="SOFA-dialog-XProtectVersionCheck/1.1"
 
 # local store
-json_cache_dir="/private/tmp/sofa"
+json_cache_dir="/var/tmp/sofa"
 json_cache="$json_cache_dir/macos_data_feed.json"
 etag_cache="$json_cache_dir/macos_data_feed_etag.txt"
 etag_cache_temp="$json_cache_dir/macos_data_feed_etag_temp.txt"

--- a/tool-scripts/XProtectVersionCheck-swiftDialog.sh
+++ b/tool-scripts/XProtectVersionCheck-swiftDialog.sh
@@ -12,7 +12,7 @@ online_json_url="https://sofafeed.macadmins.io/v1/macos_data_feed.json"
 user_agent="SOFA-dialog-XProtectVersionCheck/1.1"
 
 # local store
-json_cache_dir="/var/tmp/sofa"
+json_cache_dir="/private/var/tmp/sofa"
 json_cache="$json_cache_dir/macos_data_feed.json"
 etag_cache="$json_cache_dir/macos_data_feed_etag.txt"
 etag_cache_temp="$json_cache_dir/macos_data_feed_etag_temp.txt"

--- a/tool-scripts/macOSCVECheck-EA.sh
+++ b/tool-scripts/macOSCVECheck-EA.sh
@@ -24,7 +24,7 @@ online_json_url="https://sofafeed.macadmins.io/v1/macos_data_feed.json"
 user_agent="SOFA-Jamf-EA-macOSCVECheck/1.1"
 
 # local store
-json_cache_dir="/var/tmp/sofa"
+json_cache_dir="/private/var/tmp/sofa"
 json_cache="$json_cache_dir/macos_data_feed.json"
 etag_cache="$json_cache_dir/macos_data_feed_etag.txt"
 etag_cache_temp="$json_cache_dir/macos_data_feed_etag_temp.txt"

--- a/tool-scripts/macOSCVECheck-EA.sh
+++ b/tool-scripts/macOSCVECheck-EA.sh
@@ -24,7 +24,7 @@ online_json_url="https://sofafeed.macadmins.io/v1/macos_data_feed.json"
 user_agent="SOFA-Jamf-EA-macOSCVECheck/1.1"
 
 # local store
-json_cache_dir="/private/tmp/sofa"
+json_cache_dir="/var/tmp/sofa"
 json_cache="$json_cache_dir/macos_data_feed.json"
 etag_cache="$json_cache_dir/macos_data_feed_etag.txt"
 etag_cache_temp="$json_cache_dir/macos_data_feed_etag_temp.txt"
@@ -61,6 +61,10 @@ fi
 
 # 1. Get model (DeviceID)
 model=$(/usr/sbin/sysctl -n hw.model)
+if [[ -z "$model" ]]; then
+    echo "<result>Could not obtain model</result>"
+    exit
+fi
 echo "Model Identifier: $model"
 
 # check that the model is virtual or is in the feed at all

--- a/tool-scripts/macOSCompatibilityCheck-EA.sh
+++ b/tool-scripts/macOSCompatibilityCheck-EA.sh
@@ -29,7 +29,7 @@ online_json_url="https://sofafeed.macadmins.io/v1/macos_data_feed.json"
 user_agent="SOFA-Jamf-EA-macOSCompatibilityCheck/1.1"
 
 # local store
-json_cache_dir="/private/tmp/sofa"
+json_cache_dir="/var/tmp/sofa"
 json_cache="$json_cache_dir/macos_data_feed.json"
 etag_cache="$json_cache_dir/macos_data_feed_etag.txt"
 etag_cache_temp="$json_cache_dir/macos_data_feed_etag_temp.txt"
@@ -74,6 +74,10 @@ fi
 
 # Get model (DeviceID)
 model=$(/usr/sbin/sysctl -n hw.model)
+if [[ -z "$model" ]]; then
+    echo "<result>Could not obtain model</result>"
+    exit
+fi
 echo "Model Identifier: $model"
 
 # check that the model is virtual or is in the feed at all

--- a/tool-scripts/macOSCompatibilityCheck-EA.sh
+++ b/tool-scripts/macOSCompatibilityCheck-EA.sh
@@ -29,7 +29,7 @@ online_json_url="https://sofafeed.macadmins.io/v1/macos_data_feed.json"
 user_agent="SOFA-Jamf-EA-macOSCompatibilityCheck/1.1"
 
 # local store
-json_cache_dir="/var/tmp/sofa"
+json_cache_dir="/private/var/tmp/sofa"
 json_cache="$json_cache_dir/macos_data_feed.json"
 etag_cache="$json_cache_dir/macos_data_feed_etag.txt"
 etag_cache_temp="$json_cache_dir/macos_data_feed_etag_temp.txt"

--- a/tool-scripts/macOSVersionCheck-EA.sh
+++ b/tool-scripts/macOSVersionCheck-EA.sh
@@ -17,7 +17,7 @@ online_json_url="https://sofafeed.macadmins.io/v1/macos_data_feed.json"
 user_agent="SOFA-Jamf-EA-macOSVersionCheck/1.1"
 
 # local store
-json_cache_dir="/private/tmp/sofa"
+json_cache_dir="/var/tmp/sofa"
 json_cache="$json_cache_dir/macos_data_feed.json"
 etag_cache="$json_cache_dir/macos_data_feed_etag.txt"
 etag_cache_temp="$json_cache_dir/macos_data_feed_etag_temp.txt"
@@ -46,6 +46,10 @@ echo
 
 # 1. Get model (DeviceID)
 model=$(/usr/sbin/sysctl -n hw.model)
+if [[ -z "$model" ]]; then
+    echo "<result>Could not obtain model</result>"
+    exit
+fi
 echo "Model Identifier: $model"
 
 # check that the model is virtual or is in the feed at all

--- a/tool-scripts/macOSVersionCheck-EA.sh
+++ b/tool-scripts/macOSVersionCheck-EA.sh
@@ -17,7 +17,7 @@ online_json_url="https://sofafeed.macadmins.io/v1/macos_data_feed.json"
 user_agent="SOFA-Jamf-EA-macOSVersionCheck/1.1"
 
 # local store
-json_cache_dir="/var/tmp/sofa"
+json_cache_dir="/private/var/tmp/sofa"
 json_cache="$json_cache_dir/macos_data_feed.json"
 etag_cache="$json_cache_dir/macos_data_feed_etag.txt"
 etag_cache_temp="$json_cache_dir/macos_data_feed_etag_temp.txt"

--- a/tool-scripts/macOSVersionDisplacement-EA.sh
+++ b/tool-scripts/macOSVersionDisplacement-EA.sh
@@ -43,7 +43,7 @@ online_json_url="https://sofafeed.macadmins.io/v1/macos_data_feed.json"
 user_agent="SOFA-Jamf-EA-macOSVersionDisplacement/1.0"
 
 # Local store
-json_cache_dir="/var/tmp/sofa"
+json_cache_dir="/private/var/tmp/sofa"
 json_cache="$json_cache_dir/macos_data_feed.json"
 etag_cache="$json_cache_dir/macos_data_feed_etag.txt"
 etag_cache_temp="$json_cache_dir/macos_data_feed_etag_temp.txt"

--- a/tool-scripts/macOSVersionDisplacement-EA.sh
+++ b/tool-scripts/macOSVersionDisplacement-EA.sh
@@ -43,7 +43,7 @@ online_json_url="https://sofafeed.macadmins.io/v1/macos_data_feed.json"
 user_agent="SOFA-Jamf-EA-macOSVersionDisplacement/1.0"
 
 # Local store
-json_cache_dir="/private/tmp/sofa"
+json_cache_dir="/var/tmp/sofa"
 json_cache="$json_cache_dir/macos_data_feed.json"
 etag_cache="$json_cache_dir/macos_data_feed_etag.txt"
 etag_cache_temp="$json_cache_dir/macos_data_feed_etag_temp.txt"


### PR DESCRIPTION
Changed `/private/tmp` to `/var/tmp` due to issues experienced with the former returning older versions of the file if recently updated (why? no idea) which could cause the OS Compatibility Check to fail.

Also added in a validation check to make sure we have a model name. This wasn't directly an issue but it could potentially be so adding it in for completeness.

Each script has been tested (N=1).

Additionally `macOSCompatibilityCheck-EA.sh` has been tested in a Jamf Pro environment where the issue was first noticed 