### PR TITLE
update the quotations around model when using python2 

### DIFF
--- a/tool-scripts/macOSCompatibilityCheck-EA.sh
+++ b/tool-scripts/macOSCompatibilityCheck-EA.sh
@@ -94,7 +94,7 @@ else
     # identify the latest major OS (macOS 11- method)
     latest_os=$("$python_path" -c 'import sys, json; print json.load(sys.stdin)["OSVersions"][0]["OSVersion"]' < "$json_cache" | /usr/bin/head -n 1)
     # idenfity latest compatible major OS (macOS 11- method)
-    latest_compatible_os=$("$python_path" -c 'import sys, json; print json.load(sys.stdin)["Models"]['"$model"']["SupportedOS"][0]' < "$json_cache" | /usr/bin/head -n 1)
+    latest_compatible_os=$("$python_path" -c 'import sys, json; print json.load(sys.stdin)["Models"]["'$model'"]["SupportedOS"][0]' < "$json_cache" | /usr/bin/head -n 1)
 fi
 echo "Latest macOS: $latest_os"
 echo "Latest Compatible macOS: $latest_compatible_os"


### PR DESCRIPTION
update the quotations around model when using the python2 method for macOS 11 hosts. This fixes an issue where the model truncates on the comma (e.g. MacBookAir10,1 becomes MacBookAir10) and the lookup will then fail.

Before:
```bash
% python -c 'import sys, json; print json.load(sys.stdin)["Models"]['"$model"']["SupportedOS"][0]' < "$json_cache"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
NameError: name 'MacBookAir10' is not defined
```

After:
```bash
% python -c 'import sys, json; print json.load(sys.stdin)["Models"]["'${model}'"]["SupportedOS"][0]' < "$json_cache"
Sequoia 15
```
