### PR TITLE
Update model info for Sonoma, remove MacBook10,1

### DIFF
--- a/cache/model_identifier_sonoma.json
+++ b/cache/model_identifier_sonoma.json
@@ -45,13 +45,6 @@
         }        
     },
     {
-        "Model": "MacBook",
-        "URL": "https://support.apple.com/en-ca/103257",
-        "Identifiers": {
-            "MacBook10,1": "MacBook (Retina, 12-inch, 2017)"
-        }
-    },
-    {
         "Model": "Mac mini",
         "URL": "https://support.apple.com/en-ca/HT201894",
         "Identifiers": {


### PR DESCRIPTION
Fix for model identifier listing for Sonoma, as reported in #183. 