### PR TITLE
New EA to output the latest compatible macOS version

### DIFF
--- a/cache/gdmf_log.json
+++ b/cache/gdmf_log.json
@@ -1,9 +1,21 @@
 {
     "latest_etag": {
-        "LastCheck": "2024-10-30T04:38:00+00:00Z",
+        "LastCheck": "2024-10-30T08:39:59+00:00Z",
         "UpdateHash": "f7607b7161990060cf0c7b5c26b58b68e441da8ac5c97f4de99acd8266d6d58b"
     },
     "log": [
+        {
+            "timestamp": "2024-10-30T08:39:59+00:00Z",
+            "new_etag": "f7607b7161990060cf0c7b5c26b58b68e441da8ac5c97f4de99acd8266d6d58b",
+            "status": "success (200)",
+            "previous_etag": "f7607b7161990060cf0c7b5c26b58b68e441da8ac5c97f4de99acd8266d6d58b"
+        },
+        {
+            "timestamp": "2024-10-30T08:39:14+00:00Z",
+            "new_etag": "f7607b7161990060cf0c7b5c26b58b68e441da8ac5c97f4de99acd8266d6d58b",
+            "status": "success (200)",
+            "previous_etag": "f7607b7161990060cf0c7b5c26b58b68e441da8ac5c97f4de99acd8266d6d58b"
+        },
         {
             "timestamp": "2024-10-30T04:38:00+00:00Z",
             "new_etag": "f7607b7161990060cf0c7b5c26b58b68e441da8ac5c97f4de99acd8266d6d58b",
@@ -48,18 +60,6 @@
         },
         {
             "timestamp": "2024-10-29T20:02:07+00:00Z",
-            "new_etag": "ca5038fca097dc013bd4a979721595c5a3b831b3cd17dabde99cc63b65822633",
-            "status": "success (200)",
-            "previous_etag": "ca5038fca097dc013bd4a979721595c5a3b831b3cd17dabde99cc63b65822633"
-        },
-        {
-            "timestamp": "2024-10-29T19:02:18+00:00Z",
-            "new_etag": "ca5038fca097dc013bd4a979721595c5a3b831b3cd17dabde99cc63b65822633",
-            "status": "success (200)",
-            "previous_etag": "ca5038fca097dc013bd4a979721595c5a3b831b3cd17dabde99cc63b65822633"
-        },
-        {
-            "timestamp": "2024-10-29T19:01:40+00:00Z",
             "new_etag": "ca5038fca097dc013bd4a979721595c5a3b831b3cd17dabde99cc63b65822633",
             "status": "success (200)",
             "previous_etag": "ca5038fca097dc013bd4a979721595c5a3b831b3cd17dabde99cc63b65822633"

--- a/cache/gdmf_log.json
+++ b/cache/gdmf_log.json
@@ -1,9 +1,21 @@
 {
     "latest_etag": {
-        "LastCheck": "2024-10-30T08:39:59+00:00Z",
+        "LastCheck": "2024-10-30T08:47:45+00:00Z",
         "UpdateHash": "f7607b7161990060cf0c7b5c26b58b68e441da8ac5c97f4de99acd8266d6d58b"
     },
     "log": [
+        {
+            "timestamp": "2024-10-30T08:47:45+00:00Z",
+            "new_etag": "f7607b7161990060cf0c7b5c26b58b68e441da8ac5c97f4de99acd8266d6d58b",
+            "status": "success (200)",
+            "previous_etag": "f7607b7161990060cf0c7b5c26b58b68e441da8ac5c97f4de99acd8266d6d58b"
+        },
+        {
+            "timestamp": "2024-10-30T08:47:27+00:00Z",
+            "new_etag": "f7607b7161990060cf0c7b5c26b58b68e441da8ac5c97f4de99acd8266d6d58b",
+            "status": "success (200)",
+            "previous_etag": "f7607b7161990060cf0c7b5c26b58b68e441da8ac5c97f4de99acd8266d6d58b"
+        },
         {
             "timestamp": "2024-10-30T08:39:59+00:00Z",
             "new_etag": "f7607b7161990060cf0c7b5c26b58b68e441da8ac5c97f4de99acd8266d6d58b",
@@ -48,18 +60,6 @@
         },
         {
             "timestamp": "2024-10-29T20:35:15+00:00Z",
-            "new_etag": "ca5038fca097dc013bd4a979721595c5a3b831b3cd17dabde99cc63b65822633",
-            "status": "success (200)",
-            "previous_etag": "ca5038fca097dc013bd4a979721595c5a3b831b3cd17dabde99cc63b65822633"
-        },
-        {
-            "timestamp": "2024-10-29T20:03:02+00:00Z",
-            "new_etag": "ca5038fca097dc013bd4a979721595c5a3b831b3cd17dabde99cc63b65822633",
-            "status": "success (200)",
-            "previous_etag": "ca5038fca097dc013bd4a979721595c5a3b831b3cd17dabde99cc63b65822633"
-        },
-        {
-            "timestamp": "2024-10-29T20:02:07+00:00Z",
             "new_etag": "ca5038fca097dc013bd4a979721595c5a3b831b3cd17dabde99cc63b65822633",
             "status": "success (200)",
             "previous_etag": "ca5038fca097dc013bd4a979721595c5a3b831b3cd17dabde99cc63b65822633"

--- a/public/v1/rss_feed.xml
+++ b/public/v1/rss_feed.xml
@@ -13,7 +13,7 @@
       <link>https://sofa.macadmins.io/v1/rss_feed.xml</link>
     </image>
     <language>en</language>
-    <lastBuildDate>Wed, 30 Oct 2024 08:40:21 +0000</lastBuildDate>
+    <lastBuildDate>Wed, 30 Oct 2024 08:47:49 +0000</lastBuildDate>
     <item>
       <title>iOS 17.7.1 and iPadOS 17.7.1</title>
       <link>https://sofa.macadmins.io/</link>

--- a/public/v1/rss_feed.xml
+++ b/public/v1/rss_feed.xml
@@ -13,7 +13,7 @@
       <link>https://sofa.macadmins.io/v1/rss_feed.xml</link>
     </image>
     <language>en</language>
-    <lastBuildDate>Wed, 30 Oct 2024 04:38:24 +0000</lastBuildDate>
+    <lastBuildDate>Wed, 30 Oct 2024 08:40:21 +0000</lastBuildDate>
     <item>
       <title>iOS 17.7.1 and iPadOS 17.7.1</title>
       <link>https://sofa.macadmins.io/</link>

--- a/public/v1/timestamp.json
+++ b/public/v1/timestamp.json
@@ -1,10 +1,10 @@
 {
     "macOS": {
-        "LastCheck": "2024-10-30T08:39:53+00:00Z",
+        "LastCheck": "2024-10-30T08:47:39+00:00Z",
         "UpdateHash": "252b92b3393df5bacd36fc6ba5766fc6ca9e646c071bab1ea4eba264d05071b8"
     },
     "iOS": {
-        "LastCheck": "2024-10-30T08:40:21+00:00Z",
+        "LastCheck": "2024-10-30T08:47:49+00:00Z",
         "UpdateHash": "673c41e5cfb601876daf34f9ddd7259e8f7b1e20605349ab3c68db8af7dadf52"
     }
 }

--- a/public/v1/timestamp.json
+++ b/public/v1/timestamp.json
@@ -1,10 +1,10 @@
 {
     "macOS": {
-        "LastCheck": "2024-10-30T04:37:54+00:00Z",
+        "LastCheck": "2024-10-30T08:39:53+00:00Z",
         "UpdateHash": "252b92b3393df5bacd36fc6ba5766fc6ca9e646c071bab1ea4eba264d05071b8"
     },
     "iOS": {
-        "LastCheck": "2024-10-30T04:38:24+00:00Z",
+        "LastCheck": "2024-10-30T08:40:21+00:00Z",
         "UpdateHash": "673c41e5cfb601876daf34f9ddd7259e8f7b1e20605349ab3c68db8af7dadf52"
     }
 }

--- a/tool-scripts/macOSMaxVersionCheck-EA.sh
+++ b/tool-scripts/macOSMaxVersionCheck-EA.sh
@@ -1,0 +1,131 @@
+#!/bin/zsh --no-rcs
+# shellcheck shell=bash
+
+# Check latest available compatible version of macOS using SOFA
+# by Graham Pugh
+#
+# To use in a Smart Groups to scope computers based on max compatible macOS, e.g.:
+#   macOS Max Version - is - 14
+# 
+# For example, when using erase-install, you may wish to prevent Macs compatible with macOS 15 from 
+# upgrading to macOS 15, but wish for all older Macs to get the max compatible version.
+# In this case you can scope one policy to computers where Max Version is 15 with 
+# erase-install.sh --os 14`, and another policy to other computers (Max Version is not 15)
+# where you don't specify an --os value.
+
+# autoload is-at-least module for version comparisons
+autoload is-at-least
+
+# Get current system OS
+system_version=$( /usr/bin/sw_vers -productVersion )
+# system_version=14.1  # UNCOMMENT AND ADJUST TO TEST OLDER VERSIONS
+
+system_os=$(cut -d. -f1 <<< "$system_version")
+echo "System Version: $system_version"
+
+if [[ $system_os -ge 12 ]]; then
+    # use plistlib
+    os_compatibility="current"
+else
+    # use python 2.7
+    os_compatibility="legacy"
+    python_path="/usr/bin/python"
+fi
+
+# URL to the online JSON data
+online_json_url="https://sofafeed.macadmins.io/v1/macos_data_feed.json"
+user_agent="SOFA-Jamf-EA-macOSMaxVersionCheck/1.1"
+
+# local store
+json_cache_dir="/private/var/tmp/sofa"
+json_cache="$json_cache_dir/macos_data_feed.json"
+etag_cache="$json_cache_dir/macos_data_feed_etag.txt"
+etag_cache_temp="$json_cache_dir/macos_data_feed_etag_temp.txt"
+
+# ensure local cache folder exists
+/bin/mkdir -p "$json_cache_dir"
+
+# check local vs online using etag (only available on macOS 12+)
+if [[ -f "$etag_cache" && -f "$json_cache" ]]; then
+    etag_old=$(/bin/cat "$etag_cache")
+    /usr/bin/curl --compressed --silent --etag-compare "$etag_cache" --etag-save "$etag_cache_temp" --header "User-Agent: $user_agent" "$online_json_url" --output "$json_cache"
+    etag_temp=$(/bin/cat "$etag_cache_temp")
+    if [[ "$etag_old" == "$etag_temp" || $etag_temp == "" ]]; then
+        echo "Cached ETag matched online ETag - cached json file is up to date"
+        /bin/rm "$etag_cache_temp"
+    else
+        echo "Cached ETag did not match online ETag, so downloaded new SOFA json file"
+        /bin/mv "$etag_cache_temp" "$etag_cache"
+    fi
+elif [[ "$os_compatibility" == "legacy" ]]; then
+    echo "OS not compatible with e-tags, proceeding to download SOFA json file"
+    /usr/bin/curl --compressed --location --max-time 3 --silent --header "User-Agent: $user_agent" "$online_json_url" --output "$json_cache"
+else
+    echo "No e-tag or SOFA json file cached, proceeding to download SOFA json file"
+    /usr/bin/curl --compressed --location --max-time 3 --silent --header "User-Agent: $user_agent" "$online_json_url" --etag-save "$etag_cache" --output "$json_cache"
+fi
+
+echo
+
+if [[ ! -f "$json_cache" ]]; then
+    echo "<result>Could not obtain data</result>"
+    exit
+elif [[ "$os_compatibility" == "legacy" ]]; then
+    if ! "$python_path" -c 'import sys, json; print json.load(sys.stdin)["UpdateHash"]' < "$json_cache" > /dev/null; then
+        echo "<result>Could not obtain data</result>"
+        exit
+    fi
+elif ! /usr/bin/plutil -extract "UpdateHash" raw "$json_cache" > /dev/null; then
+    echo "<result>Could not obtain data</result>"
+    exit
+fi
+
+echo
+
+# 1. Get model (DeviceID)
+model=$(/usr/sbin/sysctl -n hw.model)
+echo "Model Identifier: $model"
+
+# check that the model is virtual or is in the feed at all
+if [[ $model == "VirtualMac"* ]]; then
+    # if virtual, we need to arbitrarily choose a model that supports all current OSes. Plucked for an M1 Mac mini
+    model="Macmini9,1"
+elif ! grep -q "$model" "$json_cache"; then
+    echo "<result>Unsupported Hardware</result>"
+    exit
+fi
+
+# 2. Get current system OS
+system_version=$( /usr/bin/sw_vers -productVersion )
+# system_version=14.1  # UNCOMMENT TO TEST OLDER VERSIONS
+system_os=$(cut -d. -f1 <<< "$system_version")
+echo "System Version: $system_version"
+
+echo
+
+# exit if less than macOS 12
+if ! is-at-least 12 "$system_os"; then
+    echo "<result>Unsupported macOS</result>"
+    exit
+fi
+
+# 3. idenfity latest compatible major OS
+latest_compatible_os=$(/usr/bin/plutil -extract "Models.$model.SupportedOS.0" raw -expect string "$json_cache" | /usr/bin/head -n 1)
+latest_compatible_os_version=$(/usr/bin/cut -d' ' -f2 <<< "$latest_compatible_os")
+
+echo "Latest Compatible macOS: $latest_compatible_os_version"
+
+# 4. Get OSVersions.Latest.ProductVersion
+for i in {0..3}; do
+    os_version=$(/usr/bin/plutil -extract "OSVersions.$i.OSVersion" raw "$json_cache" | /usr/bin/head -n 1 | grep -v "<stdin>")
+    if [[ $os_version ]]; then
+        if [[ "$os_version" == "$latest_compatible_os" ]]; then
+            product_version=$(/usr/bin/plutil -extract "OSVersions.$i.Latest.ProductVersion" raw "$json_cache" | /usr/bin/head -n 1)
+            echo "Latest Compatible macOS Version: $product_version"
+        fi
+    fi
+done
+
+echo
+
+echo "<result>$latest_compatible_os_version</result>"

--- a/v1/rss_feed.xml
+++ b/v1/rss_feed.xml
@@ -13,7 +13,7 @@
       <link>https://sofa.macadmins.io/v1/rss_feed.xml</link>
     </image>
     <language>en</language>
-    <lastBuildDate>Wed, 30 Oct 2024 08:40:21 +0000</lastBuildDate>
+    <lastBuildDate>Wed, 30 Oct 2024 08:47:49 +0000</lastBuildDate>
     <item>
       <title>iOS 17.7.1 and iPadOS 17.7.1</title>
       <link>https://sofa.macadmins.io/</link>

--- a/v1/rss_feed.xml
+++ b/v1/rss_feed.xml
@@ -13,7 +13,7 @@
       <link>https://sofa.macadmins.io/v1/rss_feed.xml</link>
     </image>
     <language>en</language>
-    <lastBuildDate>Wed, 30 Oct 2024 04:38:24 +0000</lastBuildDate>
+    <lastBuildDate>Wed, 30 Oct 2024 08:40:21 +0000</lastBuildDate>
     <item>
       <title>iOS 17.7.1 and iPadOS 17.7.1</title>
       <link>https://sofa.macadmins.io/</link>

--- a/v1/timestamp.json
+++ b/v1/timestamp.json
@@ -1,10 +1,10 @@
 {
     "macOS": {
-        "LastCheck": "2024-10-30T08:39:53+00:00Z",
+        "LastCheck": "2024-10-30T08:47:39+00:00Z",
         "UpdateHash": "252b92b3393df5bacd36fc6ba5766fc6ca9e646c071bab1ea4eba264d05071b8"
     },
     "iOS": {
-        "LastCheck": "2024-10-30T08:40:21+00:00Z",
+        "LastCheck": "2024-10-30T08:47:49+00:00Z",
         "UpdateHash": "673c41e5cfb601876daf34f9ddd7259e8f7b1e20605349ab3c68db8af7dadf52"
     }
 }

--- a/v1/timestamp.json
+++ b/v1/timestamp.json
@@ -1,10 +1,10 @@
 {
     "macOS": {
-        "LastCheck": "2024-10-30T04:37:54+00:00Z",
+        "LastCheck": "2024-10-30T08:39:53+00:00Z",
         "UpdateHash": "252b92b3393df5bacd36fc6ba5766fc6ca9e646c071bab1ea4eba264d05071b8"
     },
     "iOS": {
-        "LastCheck": "2024-10-30T04:38:24+00:00Z",
+        "LastCheck": "2024-10-30T08:40:21+00:00Z",
         "UpdateHash": "673c41e5cfb601876daf34f9ddd7259e8f7b1e20605349ab3c68db8af7dadf52"
     }
 }


### PR DESCRIPTION
This is a new extension attribute, similar to the others but specifically designed to output the latest compatible macOS major version of the device. This allows specific scoping of things like erase-install and Nudge based on major version.