### PR TITLE
Forked build descending SupportedDevices count order

### DIFF
--- a/build-sofa-feed.py
+++ b/build-sofa-feed.py
@@ -567,9 +567,13 @@ def fetch_latest_os_version_info(
             )
         ]
     if filtered_versions:
+        # Sort by device count (descending) and then by PostingDate (latest first)
         latest_version = max(
             filtered_versions,
-            key=lambda os_vers: datetime.strptime(os_vers["PostingDate"], "%Y-%m-%d"),
+            key=lambda version: (
+                len(version.get("SupportedDevices", [])),  # Prioritize larger device counts
+                datetime.strptime(version["PostingDate"], "%Y-%m-%d")  # Then by latest date
+            )
         )
         return {
             "ProductVersion": latest_version.get("ProductVersion"),


### PR DESCRIPTION
This is a hot-fix for #201 - works via prioritized larger device counts

`len(version.get("SupportedDevices", [])),`

![image](https://github.com/user-attachments/assets/982fbe5d-2ae9-4875-8efe-3665b770ab2b)

![image](https://github.com/user-attachments/assets/cfbd8626-e5e8-4ee9-94f2-514e2d50cf9e)
