### PR TITLE
Interrogate all updates and compare with known supported devices

### DIFF
--- a/build-sofa-feed.py
+++ b/build-sofa-feed.py
@@ -511,7 +511,7 @@ def update_supported_devices_in_feed(data, supported_devices_data):
 def update_devices_dict(data, supported_devices_data):
     """Update the 'SupportedDevices' in a dictionary"""
     for key, value in data.items():
-        if key == 'SupportedDevices' and not value:
+        if key == 'SupportedDevices':
             update_supported_devices(data, supported_devices_data)
         else:
             update_supported_devices_in_feed(value, supported_devices_data)
@@ -524,13 +524,22 @@ def update_devices_list(data, supported_devices_data):
 
 
 def update_supported_devices(data, supported_devices_data):
-    """Update the 'SupportedDevices' key if it's empty"""
+    """Update the 'SupportedDevices' key only if the new list has different items"""
     os_version = data.get('ProductVersion', '').split('.')[0]
+
     for supported_device in supported_devices_data:
-        supported_os_version = supported_device.get('OSVersion').split('.')[0]
+        supported_os_version = supported_device.get('OSVersion', '').split('.')[0]
+
         if os_version == supported_os_version:
-            data['SupportedDevices'] = supported_device.get('SupportedDevices', [])
-            print(f"Updated {data.get('ProductVersion')} with SupportedDevices: {data['SupportedDevices']}")
+            current_supported_devices = data.get('SupportedDevices', [])
+            new_supported_devices = supported_device.get('SupportedDevices', [])
+
+            # Sort both lists and compare
+            if sorted(current_supported_devices) != sorted(new_supported_devices):
+                data['SupportedDevices'] = new_supported_devices
+                print(f"Updated {data.get('ProductVersion')} with SupportedDevices: {data['SupportedDevices']}")
+            else:
+                print(f"No update needed for {data.get('ProductVersion')} as the SupportedDevices lists are the same.")
 
 
 def save_updated_macos_data_feed(macos_data_feed):


### PR DESCRIPTION
When looking at our current CI/CD runs we see this

```
Updated 15.0.1 with SupportedDevices: ['J132AP', 'J137AP', 'J140AAP', 'J140KAP', 'J152FAP', 'J160AP', 'J174AP', 'J180dAP', 'J185AP', 'J185FAP', 'J213AP', 'J214KAP', 'J215AP', 'J223AP', 'J230KAP', 'J274AP', 'J293AP', 'J314cAP', 'J314sAP', 'J316cAP', 'J316sAP', 'J375cAP', 'J375dAP', 'J414cAP', 'J414sAP', 'J415AP', 'J416cAP', 'J416sAP', 'J433AP', 'J434AP', 'J456AP', 'J457AP', 'J473AP', 'J474sAP', 'J475cAP', 'J475dAP', 'J493AP', 'J504AP', 'J514cAP', 'J514mAP', 'J514sAP', 'J516cAP', 'J516mAP', 'J516sAP', 'J613AP', 'J615AP', 'J680AP', 'J780AP', 'Mac-1E7E29AD0135F9BC', 'Mac-63001698E7A34814', 'Mac-937A206F2EE63C01', 'Mac-AA95B1DDAB278B95', 'VMA2MACOSAP', 'VMM-x86_64']
Updated 15.0 with SupportedDevices: ['J132AP', 'J137AP', 'J140AAP', 'J140KAP', 'J152FAP', 'J160AP', 'J174AP', 'J180dAP', 'J185AP', 'J185FAP', 'J213AP', 'J214KAP', 'J215AP', 'J223AP', 'J230KAP', 'J274AP', 'J293AP', 'J314cAP', 'J314sAP', 'J316cAP', 'J316sAP', 'J375cAP', 'J375dAP', 'J414cAP', 'J414sAP', 'J415AP', 'J416cAP', 'J416sAP', 'J433AP', 'J434AP', 'J456AP', 'J457AP', 'J473AP', 'J474sAP', 'J475cAP', 'J475dAP', 'J493AP', 'J504AP', 'J514cAP', 'J514mAP', 'J514sAP', 'J516cAP', 'J516mAP', 'J516sAP', 'J613AP', 'J615AP', 'J680AP', 'J780AP', 'Mac-1E7E29AD0135F9BC', 'Mac-63001698E7A34814', 'Mac-937A206F2EE63C01', 'Mac-AA95B1DDAB278B95', 'VMA2MACOSAP', 'VMM-x86_64']
Updated 14.6.1 with SupportedDevices: ['J132AP', 'J137AP', 'J140AAP', 'J140KAP', 'J152FAP', 'J160AP', 'J174AP', 'J180dAP', 'J185AP', 'J185FAP', 'J213AP', 'J214KAP', 'J215AP', 'J223AP', 'J230KAP', 'J274AP', 'J293AP', 'J313AP', 'J314cAP', 'J314sAP', 'J316cAP', 'J316sAP', 'J375cAP', 'J375dAP', 'J413AP', 'J414cAP', 'J414sAP', 'J415AP', 'J416cAP', 'J416sAP', 'J433AP', 'J434AP', 'J456AP', 'J457AP', 'J473AP', 'J474sAP', 'J475cAP', 'J475dAP', 'J493AP', 'J504AP', 'J514cAP', 'J514mAP', 'J514sAP', 'J516cAP', 'J516mAP', 'J516sAP', 'J613AP', 'J615AP', 'J680AP', 'J780AP', 'Mac-1E7E29AD0135F9BC', 'Mac-63001698E7A34814', 'Mac-937A206F2EE63C01', 'Mac-AA95B1DDAB278B95', 'VMA2MACOSAP', 'VMM-x86_64']
```

This change now does 

```
Updated 15.1 with SupportedDevices: ['J132AP', 'J137AP', 'J140AAP', 'J140KAP', 'J152FAP', 'J160AP', 'J174AP', 'J180dAP', 'J185AP', 'J185FAP', 'J213AP', 'J214KAP', 'J215AP', 'J223AP', 'J230KAP', 'J274AP', 'J293AP', 'J314cAP', 'J314sAP', 'J316cAP', 'J316sAP', 'J375cAP', 'J375dAP', 'J414cAP', 'J414sAP', 'J415AP', 'J416cAP', 'J416sAP', 'J433AP', 'J434AP', 'J456AP', 'J457AP', 'J473AP', 'J474sAP', 'J475cAP', 'J475dAP', 'J493AP', 'J504AP', 'J514cAP', 'J514mAP', 'J514sAP', 'J516cAP', 'J516mAP', 'J516sAP', 'J613AP', 'J615AP', 'J680AP', 'J780AP', 'J604AP', 'J614cAP', 'J614sAP', 'J616cAP', 'J616sAP', 'J623AP', 'J624AP', 'J773gAP', 'J773sAP', 'Mac-1E7E29AD0135F9BC', 'Mac-63001698E7A34814', 'Mac-937A206F2EE63C01', 'Mac-AA95B1DDAB278B95', 'VMA2MACOSAP', 'VMM-x86_64']
Updated 15.1 with SupportedDevices: ['J132AP', 'J137AP', 'J140AAP', 'J140KAP', 'J152FAP', 'J160AP', 'J174AP', 'J180dAP', 'J185AP', 'J185FAP', 'J213AP', 'J214KAP', 'J215AP', 'J223AP', 'J230KAP', 'J274AP', 'J293AP', 'J314cAP', 'J314sAP', 'J316cAP', 'J316sAP', 'J375cAP', 'J375dAP', 'J414cAP', 'J414sAP', 'J415AP', 'J416cAP', 'J416sAP', 'J433AP', 'J434AP', 'J456AP', 'J457AP', 'J473AP', 'J474sAP', 'J475cAP', 'J475dAP', 'J493AP', 'J504AP', 'J514cAP', 'J514mAP', 'J514sAP', 'J516cAP', 'J516mAP', 'J516sAP', 'J613AP', 'J615AP', 'J680AP', 'J780AP', 'J604AP', 'J614cAP', 'J614sAP', 'J616cAP', 'J616sAP', 'J623AP', 'J624AP', 'J773gAP', 'J773sAP', 'Mac-1E7E29AD0135F9BC', 'Mac-63001698E7A34814', 'Mac-937A206F2EE63C01', 'Mac-AA95B1DDAB278B95', 'VMA2MACOSAP', 'VMM-x86_64']
Updated 15.0.1 with SupportedDevices: ['J132AP', 'J137AP', 'J140AAP', 'J140KAP', 'J152FAP', 'J160AP', 'J174AP', 'J180dAP', 'J185AP', 'J185FAP', 'J213AP', 'J214KAP', 'J215AP', 'J223AP', 'J230KAP', 'J274AP', 'J293AP', 'J314cAP', 'J314sAP', 'J316cAP', 'J316sAP', 'J375cAP', 'J375dAP', 'J414cAP', 'J414sAP', 'J415AP', 'J416cAP', 'J416sAP', 'J433AP', 'J434AP', 'J456AP', 'J457AP', 'J473AP', 'J474sAP', 'J475cAP', 'J475dAP', 'J493AP', 'J504AP', 'J514cAP', 'J514mAP', 'J514sAP', 'J516cAP', 'J516mAP', 'J516sAP', 'J613AP', 'J615AP', 'J680AP', 'J780AP', 'J604AP', 'J614cAP', 'J614sAP', 'J616cAP', 'J616sAP', 'J623AP', 'J624AP', 'J773gAP', 'J773sAP', 'Mac-1E7E29AD0135F9BC', 'Mac-63001698E7A34814', 'Mac-937A206F2EE63C01', 'Mac-AA95B1DDAB278B95', 'VMA2MACOSAP', 'VMM-x86_64']
Updated 15.0 with SupportedDevices: ['J132AP', 'J137AP', 'J140AAP', 'J140KAP', 'J152FAP', 'J160AP', 'J174AP', 'J180dAP', 'J185AP', 'J185FAP', 'J213AP', 'J214KAP', 'J215AP', 'J223AP', 'J230KAP', 'J274AP', 'J293AP', 'J314cAP', 'J314sAP', 'J316cAP', 'J316sAP', 'J375cAP', 'J375dAP', 'J414cAP', 'J414sAP', 'J415AP', 'J416cAP', 'J416sAP', 'J433AP', 'J434AP', 'J456AP', 'J457AP', 'J473AP', 'J474sAP', 'J475cAP', 'J475dAP', 'J493AP', 'J504AP', 'J514cAP', 'J514mAP', 'J514sAP', 'J516cAP', 'J516mAP', 'J516sAP', 'J613AP', 'J615AP', 'J680AP', 'J780AP', 'J604AP', 'J614cAP', 'J614sAP', 'J616cAP', 'J616sAP', 'J623AP', 'J624AP', 'J773gAP', 'J773sAP', 'Mac-1E7E29AD0135F9BC', 'Mac-63001698E7A34814', 'Mac-937A206F2EE63C01', 'Mac-AA95B1DDAB278B95', 'VMA2MACOSAP', 'VMM-x86_64']
No update needed for 14.7.1 as the SupportedDevices lists are the same.
No update needed for 14.7.1 as the SupportedDevices lists are the same.
No update needed for 14.7 as the SupportedDevices lists are the same.
Updated 14.6.1 with SupportedDevices: ['J132AP', 'J137AP', 'J140AAP', 'J140KAP', 'J152FAP', 'J160AP', 'J174AP', 'J180dAP', 'J185AP', 'J185FAP', 'J213AP', 'J214KAP', 'J215AP', 'J223AP', 'J230KAP', 'J274AP', 'J293AP', 'J313AP', 'J314cAP', 'J314sAP', 'J316cAP', 'J316sAP', 'J375cAP', 'J375dAP', 'J413AP', 'J414cAP', 'J414sAP', 'J415AP', 'J416cAP', 'J416sAP', 'J433AP', 'J434AP', 'J456AP', 'J457AP', 'J473AP', 'J474sAP', 'J475cAP', 'J475dAP', 'J493AP', 'J504AP', 'J514cAP', 'J514mAP', 'J514sAP', 'J516cAP', 'J516mAP', 'J516sAP', 'J613AP', 'J615AP', 'J680AP', 'J780AP', 'Mac-1E7E29AD0135F9BC', 'Mac-63001698E7A34814', 'Mac-937A206F2EE63C01', 'Mac-AA95B1DDAB278B95', 'VMA2MACOSAP', 'VMM-x86_64']
```

Prior to this change, we were missing 15.1, 14.7.1, 13.7.1 and 12.7.6 with the correct data. The unfortunate side effect of this change is we will now blindly populate `SupportDevices` across the board with potentially incorrect data

`J604AP` for example is now added to 15.0 and 15.0.1 when we know this is incorrect.

The original intent of https://github.com/macadmins/sofa/pull/104 was to address when the data was `nil` but since these forked builds are not nil, we know face one bad behavior for another.

```
'J132AP': ['15.1', '14.7.1']
```

a json with this kind of data would be ideal to populate the data, but we currently use a flat json per OS to feed this data.