### PR TITLE
Remove non comaptible Sequoia devices

### DIFF
--- a/cache/supported_devices.json
+++ b/cache/supported_devices.json
@@ -5,8 +5,6 @@
         "SupportedDevices": [
             "J132AP",
             "J137AP",
-            "J140AAP",
-            "J140KAP",
             "J152FAP",
             "J160AP",
             "J174AP",


### PR DESCRIPTION
Fix for #218 Remove incompatible items from the list for macOS 15

J140aAP  == MacBook Air (Retina, 13-inch, 2019)
J140kAP == MacBook Air (Retina, 13-inch, 2018)