### PR TITLE
Add information for MacBook Air and Mac Studio models released in Spring 2025

### DIFF
--- a/cache/model_identifier_sonoma.json
+++ b/cache/model_identifier_sonoma.json
@@ -3,14 +3,16 @@
         "Model": "MacBook Air",
         "URL": "https://support.apple.com/en-ca/HT201862",
         "Identifiers": {
-            "Mac15,13": "MacBook Air (15-inch, M3, 2024)",
-            "Mac15,12": "MacBook Air (13-inch, M3, 2024)",
-            "Mac14,15": "MacBook Air (15-inch, M2, 2023)",
-            "Mac14,2": "MacBook Air (M2, 2022)",
-            "MacBookAir10,1": "MacBook Air (M1, 2020)",
-            "MacBookAir9,1": "MacBook Air (Retina, 13-inch, 2020)",
-            "MacBookAir8,2": "MacBook Air (Retina, 13-inch, 2019)",
-            "MacBookAir8,1": "MacBook Air (Retina, 13-inch, 2018)"
+          "Mac16,13": "MacBook Air (15-inch, M4, 2025)",
+          "Mac16,12": "MacBook Air (13-inch, M4, 2025)",
+          "Mac15,13": "MacBook Air (15-inch, M3, 2024)",
+          "Mac15,12": "MacBook Air (13-inch, M3, 2024)",
+          "Mac14,15": "MacBook Air (15-inch, M2, 2023)",
+          "Mac14,2": "MacBook Air (M2, 2022)",
+          "MacBookAir10,1": "MacBook Air (M1, 2020)",
+          "MacBookAir9,1": "MacBook Air (Retina, 13-inch, 2020)",
+          "MacBookAir8,2": "MacBook Air (Retina, 13-inch, 2019)",
+          "MacBookAir8,1": "MacBook Air (Retina, 13-inch, 2018)"
         }
     },
     {
@@ -58,6 +60,8 @@
         "Model": "Mac Studio",
         "URL": "https://support.apple.com/en-ca/HT213073",
         "Identifiers": {
+            "Mac16,9": "Mac Studio (2025)",
+            "Mac15,14": "Mac Studio (2025)",
             "Mac14,13": "Mac Studio (2023)",
             "Mac14,14": "Mac Studio (2023)",
             "Mac13,1": "Mac Studio (2022)",


### PR DESCRIPTION
Add Identifiers for new devices, updated according to: https://support.apple.com/en-us/102869 and https://support.apple.com/en-us/102231