### PR TITLE
Add back RSS link to header

### DIFF
--- a/web/.vitepress/config.mts
+++ b/web/.vitepress/config.mts
@@ -73,6 +73,7 @@ export default defineConfig({
     ],
     socialLinks: [
       { icon: 'github', link: 'https://github.com/macadmins/sofa' },
+      { icon: 'rss', link: '/v1/rss_feed.xml' },
     ],
     footer: {
       message: 'Released under the Apache 2.0 License.',


### PR DESCRIPTION
Closes #232

Add RSS link ( https://sofafeed.macadmins.io/v1/rss_feed.xml ) to header

RSS icon appears to be available at `https://api.iconify.design/simple-icons/rss.svg`

<img width="1044" height="176" alt="Screenshot 2025-07-17 at 12 00 10" src="https://github.com/user-attachments/assets/da5af666-c77c-413e-8547-fee951003637" />

This URL appears to be dynamically set in `VPSocialLink.vue`:

https://github.com/vuejs/vitepress/blob/e2a8ba04c532daa77521cd1ff15675ecf19711eb/src/client/theme-default/components/VPSocialLink.vue#L25C14-L25C53