### PR TITLE
Switch from generic SOFA link to Apple link in RSS feed

### DIFF
--- a/build-sofa-feed.py
+++ b/build-sofa-feed.py
@@ -1215,7 +1215,13 @@ def write_data_to_rss(sorted_feed: list, filename: str):
                 f"{release['ProductName']}_{release['ReleaseType']}_{release['ProductVersion']}"
             )
             feed_entry.title(release["UpdateName"])
-            feed_entry.link(href=release["SecurityInfo"])
+            feed_entry.link(
+                href=(
+                    release["SecurityInfo"]
+                    if release["SecurityInfo"].startswith("https://")
+                    else "https://sofa.macadmins.io/"
+                )
+            )
             description = ""
             if "UniqueCVEsCount" in release:
                 description += (


### PR DESCRIPTION
Currently, items in [the RSS feed](https://sofafeed.macadmins.io/v1/rss_feed.xml) (originally added in #72 by @johnnyramos) look like this (all of them have a `link` of `https://sofa.macadmins.io/`):

```xml
<item>
<title>iPadOS 17.7.9</title>
<link>https://sofa.macadmins.io/</link>
<description>Vulnerabilities Addressed: 18<br>Exploited CVE(s): 0<br>Days to Prev. Release: 71</description>
<guid isPermaLink="false">iOS_OS_17.7.9</guid>
<pubDate>Tue, 29 Jul 2025 00:00:00 +0000</pubDate>
</item>

<item>
<title>iOS 18.6 and iPadOS 18.6</title>
<link>https://sofa.macadmins.io/</link>
<description>Vulnerabilities Addressed: 29<br>Exploited CVE(s): 0<br>Days to Prev. Release: 78</description>
<guid isPermaLink="false">iOS_OS_18.6</guid>
<pubDate>Tue, 29 Jul 2025 00:00:00 +0000</pubDate>
</item>
```

This PR aims to use the `SecurityInfo` property of each `release` dictionary to link to each Apple information page (if the string starts with `https://` - if not, then fall back to `https://sofa.macadmins.io/`):

```xml
<item>
<title>iPadOS 17.7.9</title>
<link>https://support.apple.com/en-ca/124148</link>
<description>Vulnerabilities Addressed: 18<br>Exploited CVE(s): 0<br>Days to Prev. Release: 71</description>
<guid isPermaLink="false">iOS_OS_17.7.9</guid>
<pubDate>Tue, 29 Jul 2025 00:00:00 +0000</pubDate>
</item>

<item>
<title>iOS 18.6 and iPadOS 18.6</title>
<link>https://support.apple.com/en-ca/124147</link>
<description>Vulnerabilities Addressed: 29<br>Exploited CVE(s): 0<br>Days to Prev. Release: 78</description>
<guid isPermaLink="false">iOS_OS_18.6</guid>
<pubDate>Tue, 29 Jul 2025 00:00:00 +0000</pubDate>
</item>
```