### PR TITLE
Add Tahoe to v1 feed building 

### DIFF
--- a/build-sofa-feed.py
+++ b/build-sofa-feed.py
@@ -278,6 +278,7 @@ def process_os_type(os_type: str, config: dict, gdmf_data: dict) -> list:
         feed_structure["XProtectPlistConfigData"] = plist_info
         # Load and tag model data
         model_files = [
+            ("model_identifier_tahoe.json", "macOS Tahoe 26"),
             ("model_identifier_sequoia.json", "macOS Sequoia 15"),
             ("model_identifier_sonoma.json", "macOS Sonoma 14"),
             ("model_identifier_ventura.json", "macOS Ventura 13"),

--- a/cache/model_identifier_tahoe.json
+++ b/cache/model_identifier_tahoe.json
@@ -1,0 +1,91 @@
+[
+    {
+        "Model": "MacBook Air",
+        "URL": "https://support.apple.com/en-ca/HT201862",
+        "Identifiers": {
+            "Mac16,13": "MacBook Air (15-inch, M4, 2025)",
+            "Mac16,12": "MacBook Air (13-inch, M4, 2025)",
+            "Mac15,13": "MacBook Air (15-inch, M3, 2024)",
+            "Mac15,12": "MacBook Air (13-inch, M3, 2024)",
+            "Mac14,15": "MacBook Air (15-inch, M2, 2023)",
+            "Mac14,2": "MacBook Air (M2, 2022)",
+            "MacBookAir10,1": "MacBook Air (M1, 2020)"
+        }
+    },
+    {
+        "Model": "MacBook Pro",
+        "URL": "https://support.apple.com/en-ca/HT201300",
+        "Identifiers": {
+            "Mac16,1": "MacBook Pro (14-inch, 2024)",
+            "Mac16,5": "MacBook Pro (14-inch, 2024)",
+            "Mac16,6": "MacBook Pro (14-inch, 2024)",
+            "Mac16,7": "MacBook Pro (14-inch, 2024)",
+            "Mac16,8": "MacBook Pro (14-inch, 2024)",
+            "Mac15,3": "MacBook Pro (14-inch, Nov 2023)",
+            "Mac15,6": "MacBook Pro (14-inch, Nov 2023)",
+            "Mac15,8": "MacBook Pro (14-inch, Nov 2023)",
+            "Mac15,10": "MacBook Pro (14-inch, Nov 2023)",
+            "Mac15,7": "MacBook Pro (16-inch, Nov 2023)",
+            "Mac15,9": "MacBook Pro (16-inch, Nov 2023)",
+            "Mac15,11": "MacBook Pro (16-inch, Nov 2023)",
+            "Mac14,5": "MacBook Pro (14-inch, 2023)",
+            "Mac14,9": "MacBook Pro (14-inch, 2023)",
+            "Mac14,6": "MacBook Pro (16-inch, 2023)",
+            "Mac14,10": "MacBook Pro (16-inch, 2023)",
+            "Mac14,7": "MacBook Pro (13-inch, M2, 2022)",
+            "MacBookPro18,3": "MacBook Pro (14-inch, 2021)",
+            "MacBookPro18,4": "MacBook Pro (14-inch, 2021)",
+            "MacBookPro18,1": "MacBook Pro (16-inch, 2021)",
+            "MacBookPro18,2": "MacBook Pro (16-inch, 2021)",
+            "MacBookPro17,1": "MacBook Pro (13-inch, M1, 2020)",
+            "MacBookPro16,2": "MacBook Pro (13-inch, 2020, Four Thunderbolt 3 ports)",
+            "MacBookPro16,1": "MacBook Pro (16-inch, 2019)",
+            "MacBookPro16,4": "MacBook Pro (16-inch, 2019)"
+        }        
+    },
+    {
+        "Model": "Mac mini",
+        "URL": "https://support.apple.com/en-ca/HT201894",
+        "Identifiers": {
+            "Mac16,11": "Mac mini (2024)",
+            "Mac16,10": "Mac mini (2024)",
+            "Mac14,3": "Mac mini (2023)",
+            "Mac14,12": "Mac mini (2023)",
+            "Macmini9,1": "Mac mini (M1, 2020)"
+        }
+    },
+    {
+        "Model": "Mac Studio",
+        "URL": "https://support.apple.com/en-ca/HT213073",
+        "Identifiers": {
+            "Mac16,9": "Mac Studio (2025)",
+            "Mac15,14": "Mac Studio (2025)",
+            "Mac14,13": "Mac Studio (2023)",
+            "Mac14,14": "Mac Studio (2023)",
+            "Mac13,1": "Mac Studio (2022)",
+            "Mac13,2": "Mac Studio (2022)"
+        }
+    },
+    {
+        "Model": "iMac",
+        "URL": "https://support.apple.com/en-ca/HT201634",
+        "Identifiers": {
+            "Mac16,2": "iMac (24-inch, 2024, Two ports)",
+            "Mac16,3": "iMac (24-inch, 2024, Four ports)",
+            "Mac15,5": "iMac (24-inch, 2023)",
+            "Mac15,4": "iMac (24-inch, 2023)",
+            "iMac21,1": "iMac (24-inch, M1, 2021)",
+            "iMac21,2": "iMac (24-inch, M1, 2021)",
+            "iMac20,1": "iMac (Retina 5K, 27-inch, 2020)",
+            "iMac20,2": "iMac (Retina 5K, 27-inch, 2020)"
+        }
+    },
+    {
+        "Model": "Mac Pro",
+        "URL": "https://support.apple.com/en-ca/HT202888",
+        "Identifiers": {
+            "Mac14,8": "Mac Pro (2023)",
+            "MacPro7,1": "Mac Pro (2019)"
+        }
+    }
+]

--- a/config.json
+++ b/config.json
@@ -1,6 +1,11 @@
 {
     "softwareReleases": [
       {
+        "id": "tahoe-26",
+        "name": "Tahoe 26",
+        "osType": "macOS"
+      },
+      {
         "id": "sequoia-15",
         "name": "Sequoia 15",
         "osType": "macOS"
@@ -19,6 +24,11 @@
         "id": "monterey-12",
         "name": "Monterey 12",
         "osType": "macOS"
+      },
+      {
+        "id": "ios-26",
+        "name": "26",
+        "osType": "iOS"
       },
       {
         "id": "ios-18",


### PR DESCRIPTION
- Add model_identifier_tahoe.json to cache folder
- Add tahoe and iOS 26 to config.json
- Reference the model_files model_identifier_tahoe.json in `build-sofa-feed.py`