### PR TITLE
Fix link to IPSW

### DIFF
--- a/web/components/LatestFeatures.vue
+++ b/web/components/LatestFeatures.vue
@@ -18,8 +18,8 @@
           <p><strong>Release Date:</strong> {{ formatDate(osData.Latest.ReleaseDate) }}</p>
           <p><strong>Days Since Release:</strong> {{ daysSinceRelease(osData.Latest.ReleaseDate) }}</p>
 
-          <!-- Display installer info for Sequoia 15 (macOS only) -->
-          <div v-if="platform === 'macOS' && osData.OSVersion === 'Sequoia 15'">
+          <!-- Display installer info for Tahoe 26 (macOS only) -->
+          <div v-if="platform === 'macOS' && osData.OSVersion === 'Tahoe 26'">
             <p v-if="installationApps?.LatestUMA?.url">
               <strong>Installer Package: </strong>
               <a :href="installationApps.LatestUMA.url" target="_blank">Download</a>
@@ -30,7 +30,7 @@
             </p>
           </div>
           <!-- General installer info link for macOS (not displayed on iOS) -->
-          <div v-if="platform === 'macOS' && osData.OSVersion !== 'Sequoia 15'">
+          <div v-if="platform === 'macOS' && osData.OSVersion !== 'Tahoe 26'">
             <strong>Installer Package (UMA): </strong>
             <a href="/macos_installer_info.html#release-information-table">Download links</a>
           </div>


### PR DESCRIPTION
Fixed UI, as it was avail under macOS 15 but pointing to macOS 26 IPSW. Now IPSW is under Tahoe.

alternative for IPSW downloads of older OS versions cloud be pointing folks to https://appledb.dev/firmware.html  