### PR TITLE
Restrict workflows from running on forks

### DIFF
--- a/.github/workflows/01_sofa-build-pipeline.yml
+++ b/.github/workflows/01_sofa-build-pipeline.yml
@@ -32,7 +32,8 @@ jobs:
   pipeline:
     name: SOFA Production Pipeline
     runs-on: ubuntu-latest
-    
+    if: github.event.repository.fork == false
+
     steps:
       - name: Setup processing directory
         run: |

--- a/.github/workflows/02_r2-upload.yml
+++ b/.github/workflows/02_r2-upload.yml
@@ -15,7 +15,7 @@ jobs:
   upload-to-r2:
     name: Upload SOFA Feeds to R2
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    if: github.event.repository.fork == false && (github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success')
 
     steps:
       - name: 📥 Checkout repository

--- a/.github/workflows/03_sofa-deploy-feeds.yml
+++ b/.github/workflows/03_sofa-deploy-feeds.yml
@@ -27,7 +27,7 @@ jobs:
   deploy:
     name: Deploy Feeds to DigitalOcean
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch'
+    if: github.event.repository.fork == false && (github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch')
     
     steps:
       - name: Checkout repository

--- a/.github/workflows/04_cloudflare-cache-purge.yml
+++ b/.github/workflows/04_cloudflare-cache-purge.yml
@@ -36,7 +36,7 @@ jobs:
   purge-cache:
     name: Purge Cloudflare Cache
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch'
+    if: github.event.repository.fork == false && (github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch')
 
     steps:
       - name: Setup cache purge environment

--- a/.github/workflows/05_pull_public-metrics.yml
+++ b/.github/workflows/05_pull_public-metrics.yml
@@ -29,7 +29,8 @@ concurrency:
 jobs:
   fetch-metrics:
     runs-on: ubuntu-latest
-    
+    if: github.event.repository.fork == false
+
     env:
       PRIVATE_REPO_TOKEN: ${{ secrets.PRIVATE_REPO_TOKEN }}
       METRICS_PATH: ${{ inputs.metrics_path || vars.METRICS_OUTPUT_PATH || 'data/resources/metrics.json' }}

--- a/.github/workflows/06_cve-pipeline.yml
+++ b/.github/workflows/06_cve-pipeline.yml
@@ -22,6 +22,7 @@ jobs:
   test-cve-pipeline:
     name: CVE Pipeline
     runs-on: ubuntu-latest
+    if: github.event.repository.fork == false
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Add condition to all GitHub Actions workflows to prevent aut-trigger in from forked repositories. 

as reported #270 