### PR TITLE
Update VPDocFooter

### DIFF
--- a/web/.vitepress/config.mts
+++ b/web/.vitepress/config.mts
@@ -35,11 +35,11 @@ export default defineConfig({
     // Ensure mobile navigation works
     siteTitle: 'SOFA',
     logo: '/custom_logo.png',
-    
-    // Disable next/prev page links if desired
+
+    // Disable next/prev page links if desired by setting values to false. Comment out docFooter for default values of 'Previous page' and 'Next page'
     docFooter: {
-      prev: true,
-      next: true,
+      prev: 'Previous',
+      next: 'Next',
     },
     
     sidebar: [


### PR DESCRIPTION
VPDocFooter used to say 'true' for the previous and next buttons, now they are depicted accurately.

Images to show change:
On 'wiki' style page, like [https://sofa.macadmins.io/scheduled-process](https://sofa.macadmins.io/scheduled-process)
This:
<img width="815" height="90" alt="Screenshot 2025-10-15 at 3 08 33 PM" src="https://github.com/user-attachments/assets/4c5efa98-f8a0-4c12-af9a-0b0d15386965" />

Changes to:
<img width="812" height="82" alt="Screenshot 2025-10-15 at 3 11 16 PM" src="https://github.com/user-attachments/assets/e9d5fa85-6852-4198-9838-5aa68fed4037" />

