### PR TITLE
Bug/metadata links broken

### DIFF
--- a/web/.vitepress/theme/components/HowItWorksBento.vue
+++ b/web/.vitepress/theme/components/HowItWorksBento.vue
@@ -455,7 +455,6 @@ const v1Feeds = ref([
 
 const metaFeeds = ref([
   { name: 'sofa-status.json', url: '/resources/sofa-status.json', important: true },
-  // when testing locally, the shortened url seem to work but on sofa.macadmins.io they don't seem to. Something with the deployment, I would guess.
   { name: 'bulletin_data.json', url: '/resources/bulletin_data.json', important: true },
   { name: 'essential_links.json', url: '/resources/essential_links.json', important: true },
   { name: 'timestamp.json', url: '/resources/timestamp.json'}


### PR DESCRIPTION
Replaced shortened urls of bulletin_data.json and essential_links.json feeds.

The short links work when testing on my local machine with `npm run dev` but they don't work on the [https://sofa.macadmins.io/how-it-works](https://sofa.macadmins.io/how-it-works) page. So might be a GitHub Actions / CI/CD issue, this could be a temporary fix if you really want shorter urls.

Not super related to #278 but I mentioned it in my comment.