### PR TITLE
v2 PascalCase schema, Release Timeline, Signed Versions, dark mode fix

### DIFF
--- a/web/getting-started.md
+++ b/web/getting-started.md
@@ -22,7 +22,7 @@ SOFA's modern interface provides comprehensive tracking across all Apple platfor
 ### Platform Coverage
 
 - **macOS** (Tahoe 26, Sequoia 15, Sonoma 14, Ventura 13, Monterey 12) - Complete version tracking with XProtect data
-- **iOS/iPadOS** (2618, 17) - Latest releases and security updates for mobile devices  
+- **iOS/iPadOS** (26, 18, 17) - Latest releases and security updates for mobile devices  
 - **Safari** (18) - Browser security updates across all platforms
 - **tvOS** (26, 18, 17) - Apple TV platform updates and security fixes
 - **watchOS** (26, 11) - Apple Watch updates and compatibility tracking

--- a/web/package.json
+++ b/web/package.json
@@ -4,6 +4,7 @@
     "@tailwindcss/postcss": "^4.2.2",
     "autoprefixer": "^10.4.23",
     "postcss": "^8.5.6",
+    "preact": "10.28.4",
     "tailwindcss": "^4.2.2",
     "vitepress": "^1.6.4"
   },

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
       postcss:
         specifier: ^8.5.6
         version: 8.5.6
+      preact:
+        specifier: 10.28.4
+        version: 10.28.4
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -899,8 +902,8 @@ packages:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
-  preact@10.26.5:
-    resolution: {integrity: sha512-fmpDkgfGU6JYux9teDWLhj9mKN55tyepwYbxHgQuIxbWQzgFg5vk7Mrrtfx7xRxq798ynkY4DDDxZr235Kk+4w==}
+  preact@10.28.4:
+    resolution: {integrity: sha512-uKFfOHWuSNpRFVTnljsCluEFq57OKT+0QdOiQo8XWnQ/pSvg7OpX5eNOejELXJMWy+BwM2nobz0FkvzmnpCNsQ==}
 
   property-information@7.0.0:
     resolution: {integrity: sha512-7D/qOz/+Y4X/rzSB6jKxKUsQnphO046ei8qxG59mtM3RG3DHgTK81HrxrmoDVINJb8NKT5ZsRbwHvQ6B68Iyhg==}
@@ -1167,7 +1170,7 @@ snapshots:
   '@docsearch/js@3.8.2(@algolia/client-search@5.23.4)(search-insights@2.17.3)':
     dependencies:
       '@docsearch/react': 3.8.2(@algolia/client-search@5.23.4)(search-insights@2.17.3)
-      preact: 10.26.5
+      preact: 10.28.4
     transitivePeerDependencies:
       - '@algolia/client-search'
       - '@types/react'
@@ -1842,7 +1845,7 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  preact@10.26.5: {}
+  preact@10.28.4: {}
 
   property-information@7.0.0: {}
 


### PR DESCRIPTION
## Summary

- **Vue components migrated** to v2 PascalCase schema (2026.04.11.2) — SecurityInfo, ReleaseInstallerTable, FeedInfo
- **Release Timeline** — new git-branch SVG visualization of release chains showing device-specific branches and BSI entries, with Mermaid/Markdown export
- **Signed Versions** — admin-friendly view of currently signed OS versions with grouped device tables (Model, Identifier, Board ID), Markdown export
- **Dark mode fix** — Tailwind 4 `@custom-variant` for VitePress `.dark` class strategy, removed blanket `!important` overrides from bento-system.css
- **Static data** — device_lookup.json expanded with 13 Intel Mac board IDs, mac_models_mapping.json corrected per AppleDB cross-validation
- **Pipeline** — bumped to sofa-core-cli v0.3.0
- **Security** — bumped preact 10.26.5 → 10.28.4 (fixes GHSA-36hm-qxxp-pg3m), resolves dependabot PR #300

## Details

### Schema migration
The v2 feeds now use PascalCase fields (`UpdateSummary.Summary`, `MacOSIPSWVersion`, `ActivelyExploitedCVEs`). Vue components updated to match — old snake_case/camelCase fallback paths removed.

### Release Timeline (`/release-timeline`)
SVG graph showing the release chain per platform. Device-specific releases (like macOS 26.3.2 for MacBook Neo) branch off and merge back — like git branches. BSI entries appear as purple diamonds with their own dates. Includes Copy Markdown / Download .md with Mermaid gitGraph diagrams.

### Signed Versions (`/signed-versions`)
Simple card view for admins: what's currently signed, CVE counts, device support grouped by product type (MacBook Pro, Air, iMac, Mac mini, etc.) with identifiers and board IDs. Handles unsigned versions gracefully ("No longer signed" badge).

### Dark mode
Root cause: Tailwind 4 defaults to `prefers-color-scheme` media query, ignoring VitePress's `.dark` class toggle. Fixed with `@custom-variant dark` in both tailwind.css and bento-system.css.

### Device data
- `device_lookup.json`: +13 Intel Mac board IDs (2018-2020 models) validated against AppleDB + Mactracker
- `mac_models_mapping.json`: 3 name corrections per AppleDB, added MacBookPro16,1 with Tahoe 26 support (confirmed via InstallAssistant manifest)

### Security audit
`pnpm audit` shows 3 remaining vulnerabilities (1 high, 2 moderate) in transitive dependencies of VitePress (rollup, esbuild, vite). These are all **build/dev-time vulnerabilities, not runtime — they don't affect the deployed static site**. Fixes depend on upstream VitePress releases. The preact JSON VNode Injection vulnerability (high) has been resolved by bumping to 10.28.4.

## Test plan
- [ ] `/release-timeline` — SVG renders for macOS and iOS
- [ ] iOS 18 — 3 device-specific branches merge into 18.7.7
- [ ] Click version labels — navigates to security page with `?version=` deep link
- [ ] `/signed-versions` — device tables grouped by product type
- [ ] Toggle dark/light mode on dark-mode device — cards follow VitePress toggle
- [ ] `/macos/tahoe` SecurityInfo — UpdateSummary renders with Summary/Recommendation
- [ ] `/macos-installer-info` — IPSW/UMA data displays correctly
- [ ] Copy Markdown / Download .md — Mermaid diagram renders in GitHub