### PR TITLE
Fix pipeline: restore fork == false for upstream

### DIFF
--- a/.github/workflows/01_sofa-build-pipeline.yml
+++ b/.github/workflows/01_sofa-build-pipeline.yml
@@ -32,7 +32,7 @@ jobs:
   pipeline:
     name: SOFA Production Pipeline
     runs-on: ubuntu-latest
-    if: github.event.repository.fork == true
+    if: github.event.repository.fork == false
 
     steps:
       - name: Setup processing directory


### PR DESCRIPTION
The previous PR (#308) included `fork == true` which was needed for testing on the headmin fork. This blocks the pipeline on macadmins/sofa (which is not a fork).

Restores `github.event.repository.fork == false` so the scheduled pipeline runs again.