### PR TITLE
Small fix to pull iOS 26.5.1

### DIFF
--- a/scripts/build_legacy_v1_feeds.py
+++ b/scripts/build_legacy_v1_feeds.py
@@ -53,7 +53,7 @@ from typing import Dict, List, Optional, Any
 
 # OS Version ranges to include in feeds (to match live feeds)
 OS_RANGE_MACOS = ["12", "13", "14", "15", "26"]
-OS_RANGE_IOS = ["16", "17", "18" "26"]  # Including 16 to match live feed
+OS_RANGE_IOS = ["16", "17", "18", "26"]  # Including 16 to match live feed
 
 # macOS version name transformation table to match live feed schema
 MACOS_NAME_TRANSFORM = {

--- a/scripts/build_legacy_v1_feeds.py
+++ b/scripts/build_legacy_v1_feeds.py
@@ -387,15 +387,20 @@ def group_versions_by_major(versions: List[Dict], os_type: str) -> Dict[str, Lis
 
 
 def get_latest_version_info(versions: List[Dict]) -> Optional[Dict]:
-    """Get the latest version from a list, preferring higher device count and newer date"""
+    """Get the latest version from a list, preferring higher version number then newer date"""
     if not versions:
         return None
-    
-    latest = max(versions, key=lambda v: (
-        len(v.get("SupportedDevices", [])),  # Prefer more devices
-        v.get("PostingDate", ""),            # Then newer date
-        v.get("ProductVersion", "")          # Then version number
-    ))
+
+    def version_sort_key(v):
+        pv = v.get("ProductVersion", "")
+        try:
+            # Parse version tuple numerically so e.g. 26.5.1 > 26.5 > 18.x
+            parts = tuple(int(x) for x in pv.split("."))
+        except ValueError:
+            parts = (0,)
+        return (parts, v.get("PostingDate", ""))
+
+    latest = max(versions, key=version_sort_key)
     
     return {
         "ProductVersion": latest.get("ProductVersion", ""),


### PR DESCRIPTION
When `major_version` not in `allowed_versions` get skipped

Testing:

```
python3 scripts/build_legacy_v1_feeds.py iOS
📦 Using pre-fetched GDMF data from cache
🔧 Processing iOS...
Updated 26.5.1 ReleaseDate from 2026-06-01T00:00:00Z to 2026-06-01T00:00:00Z
Updated 18.7.9 ReleaseDate from 2026-06-01T00:00:00Z to 2026-05-11T00:00:00Z
Updated 17.7.11 ReleaseDate from 2026-06-01T00:00:00Z to 2026-05-11T00:00:00Z
Updated 16.7.16 ReleaseDate from 2026-06-01T00:00:00Z to 2026-05-11T00:00:00Z
✅ Created: ios_data_feed.json
✅ Successfully built 1 legacy v1 feed(s)

```